### PR TITLE
CrewTradeを問い中心の金融調査ワークスペースへ再設計

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,8 +20,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - run: uv sync
-      - run: uv run python web/build_static.py
+      - name: Install dependencies
+        run: uv sync
+      - name: Compile web code
+        run: uv run python -m compileall -q web
+      - name: Build static site
+        run: uv run python web/build_static.py
+      - name: Audit generated site
+        run: uv run python web/audit_static.py
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs

--- a/README.md
+++ b/README.md
@@ -1,60 +1,69 @@
-# CrewTrade — マルチエージェント金融調査・時系列分析
+# CrewTrade — 金融調査ワークスペース
 
-**公開ダッシュボード:** https://kafka2306.github.io/CrewTrade/
+[公開ダッシュボード](https://kafka2306.github.io/CrewTrade/) · [GitHub Actions](https://github.com/KAFKA2306/CrewTrade/actions)
 
-CrewTradeは、CrewAIを用いて金融データの取得、定量分析、レポート生成、時系列予測をユースケースごとに実行する研究プロジェクトです。
+CrewTradeは、市場データの取得、定量計算、時系列予測、文章による解釈をユースケース単位で実行し、分析スナップショットとして公開する研究プロジェクトです。
 
-市場データ、計算結果、モデル予測、文章による解釈を分離し、インサンプル成績だけで投資戦略の有効性を断定しないことを前提とします。
+公開画面は、レポート名の一覧ではなく、**何を検証する分析なのか**を起点に設計しています。対象・期間・計算条件・予測・解釈を同じ証拠として扱わず、レポート本文でそれぞれ確認できる状態を目指します。
 
-## 主な機能
+## 公開画面
 
-- Yahoo Financeなどからの市場データ取得
-- 株式、ETF、金利、金属、半導体の分析
-- ポートフォリオと証券担保ローンのリスク計算
-- 基準指数とのリターン・リスク比較
-- インサンプルとアウト・オブ・サンプルの分離
-- CrewAIによる調査・分析タスクの分担
-- Amazon Chronos系モデルを使った時系列予測実験
-- Markdown・画像・静的HTMLレポートの生成
-- GitHub Pagesへの分析結果公開
+- 調査テーマを「運用評価」「資産配分」「リスク管理」「産業分析」などの検証目的で整理
+- テーマ、問い、説明文を横断検索
+- 各テーマの最新スナップショットと公開レポート数を表示
+- 日付別レポートを切り替えて、前提や結論の変化を追跡
+- レポート画像・添付物を日付別アセットへ分離し、同名ファイルの上書きを防止
+- 掲載値がリアルタイムではないこと、投資助言ではないことを画面内に明示
 
-## 公開処理
+デザインは、背景 `#fbfaf7`、本文 `#243653`、青 `#8fb5ec`、ラベンダー `#b9a8e6`、ローズ `#efb4c1`、ミント `#b7dbc8`、アプリコット `#f3cfaa` を基調としています。
 
-GitHub Actionsは、`main`への変更時に依存関係を同期し、`web/build_static.py`で`docs/`を生成してGitHub Pagesへ公開します。
+## 調査テーマ
 
-公開ダッシュボードは、ユースケースごとに生成済みレポートを一覧表示します。掲載値は各レポートの作成日時点の結果であり、リアルタイム価格ではありません。
-
-## 主なユースケース
-
-| ユースケース | 設定ファイル | 主な目的 |
+| 公開スラッグ | 表示名 | 主な検証軸 |
 | --- | --- | --- |
-| `imura` | `config/use_cases/imura.yaml` | ファンド・指数比較、リターンとリスク分析 |
-| `oracle` | `config/use_cases/oracle.yaml` | 個別企業・時系列予測の研究 |
-| `credit` | `config/use_cases/credit.yaml` | 信用・クレジット関連分析 |
-| `etf` | — | ETF比較 |
-| `loan` | `config/use_cases/loan.yaml` | 証券担保ローンなどのリスク分析 |
-| `metals` | `config/use_cases/metals.yaml` | 金属・コモディティ分析 |
-| `portfolio` | `config/use_cases/portfolio.yaml` | ポートフォリオ分析 |
-| `yields` | `config/use_cases/yields.yaml` | 金利・利回り分析 |
-| `semiconductors` | `config/use_cases/semiconductors.yaml` | 半導体関連分析 |
-| `legendary_investors` | `config/use_cases/legendary_investors.yaml` | 著名投資家の公開情報を用いた調査 |
+| `imura` | ファンド・指数比較 | 比較条件とリスクをそろえても超過収益が残るか |
+| `index_7_portfolio` | 7指数ポートフォリオ | 分散が実際の下落局面で機能したか |
+| `index_etf_comparison` | 指数ETF比較 | 同じ指数名でも投資結果を分ける条件は何か |
+| `legendary_investors` | 著名投資家リサーチ | 公開情報から再現可能な判断原則を抽出できるか |
+| `oracle` | 個別企業・時系列予測 | 予測がアウト・オブ・サンプルでも情報を持つか |
+| `precious_metals_spread` | 貴金属スプレッド | 価格差が平均回帰か構造変化か |
+| `securities_collateral_loan` | 証券担保ローン | どの下落率から意思決定の自由が失われるか |
+| `semiconductors` | 半導体サイクル | 利益成長が数量・価格・能力のどこから生じたか |
+| `yield_spread` | 金利・イールドスプレッド | 金利差の変化がどの期待を反映しているか |
 
-設定ファイルが存在しないユースケースは、実装内の既定値または個別スクリプトを使用します。
+未登録の出力ディレクトリは削除せず、「未分類」として表示します。名称や説明を推測で補完しません。
 
-## 技術構成
+## ディレクトリ構造
 
-- Python 3.11
-- CrewAI
-- `uv`
-- pandas / NumPy
-- yfinance / yahooquery / pandas-datareader
-- PyTorch / Transformers / Chronos Forecasting
-- Nixtla
-- Flask
-- Matplotlib
-- Playwright・Crawl4AI系の取得処理
+```text
+config/use_cases/           ユースケース設定
+output/use_cases/           分析結果の正本
+  <use_case>/<YYYYMMDD>/
+    report.md               公開対象Markdown
+    *.png / *.csv / ...     レポート添付物
+web/
+  catalog.py                表示名・分類・検証軸の定義
+  build_static.py           GitHub Pages生成器
+  audit_static.py           生成物監査
+  static/                   共通CSS・JavaScript
+  templates/                Jinjaテンプレート
+docs/                       生成された静的サイト
+```
 
-依存関係の正本は`pyproject.toml`です。
+分析結果の正本は `output/use_cases/` です。`docs/` は `web/build_static.py` から再生成されます。
+
+## 公開ロジック
+
+1. `output/use_cases/<use_case>/<date>/` を列挙
+2. 公開対象Markdownを決定
+3. テーマ情報を `web/catalog.py` から付与
+4. MarkdownをHTMLへ変換
+5. 添付物を `docs/<use_case>/assets/<date>/` へコピー
+6. `docs/site-manifest.json` に公開テーマと日付を記録
+7. `web/audit_static.py` で言語設定、テンプレート残存、旧UI残存を検査
+8. GitHub Pagesへデプロイ
+
+同一日付ディレクトリに複数のMarkdownがあり、`report.md` または `analysis_report.md` で公開対象を一意に決められない場合、ビルドは失敗します。曖昧なファイルを任意に選んで成功扱いしません。
 
 ## セットアップ
 
@@ -62,16 +71,24 @@ GitHub Actionsは、`main`への変更時に依存関係を同期し、`web/buil
 uv sync
 ```
 
-Python要件は`>=3.11,<3.12`です。
+Python要件は `>=3.11,<3.12` です。依存関係の正本は `pyproject.toml` です。
 
-APIキーや外部サービスの認証情報が必要なユースケースでは、ローカルの環境変数または非公開設定を使用してください。秘密情報をコミットしないでください。
+APIキーや外部サービスの認証情報は環境変数または非公開設定で管理し、リポジトリへコミットしないでください。
 
 ## 実行
 
 ```bash
-task process:all   # データ取得から分析までをまとめて実行
+task process:all   # データ取得から分析まで実行
 task fetch:all     # データ取得
-task run           # 分析を実行
+task run           # 分析実行
+task serve         # ローカルWeb画面
+```
+
+静的サイトのみを生成・監査する場合:
+
+```bash
+uv run python web/build_static.py
+uv run python web/audit_static.py
 ```
 
 CLIエントリポイント:
@@ -84,17 +101,11 @@ uv run replay
 uv run test
 ```
 
-Web画面をローカルで起動するタスクが利用できる構成では、次を実行します。
-
-```bash
-task serve
-```
-
 ## 分析品質の確認項目
 
 - データの対象期間と取得日時を残す
-- 配当・分割・通貨・市場休業日の扱いを明示する
-- インサンプルとOOSを分離する
+- 配当、分割、通貨、市場休業日の扱いを明示する
+- インサンプルとアウト・オブ・サンプルを分離する
 - 比較指数と計算条件をそろえる
 - 手数料、税、スリッページを含まない結果を実績と呼ばない
 - 予測モデルの入力期間、予測期間、評価指標を保存する
@@ -103,9 +114,9 @@ task serve
 
 ## 注意
 
+- 掲載値は各レポート作成日時点のスナップショットです
 - 過去の成績は将来の収益を保証しません
 - Chronosなどの予測値は確定的な将来価格ではありません
-- 公開レポートの数値は、作成時点のデータと実装に依存します
 - 本プロジェクトは投資助言、売買推奨、運用実績の保証ではありません
 
-**README最終監査:** 2026-08-01
+**最終構造監査:** 2026-08-02

--- a/web/audit_static.py
+++ b/web/audit_static.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = PROJECT_ROOT / "docs"
+
+
+def audit() -> None:
+    required = [
+        DOCS_DIR / "index.html",
+        DOCS_DIR / "assets" / "site.css",
+        DOCS_DIR / "assets" / "site.js",
+        DOCS_DIR / "site-manifest.json",
+    ]
+    missing = [str(path.relative_to(PROJECT_ROOT)) for path in required if not path.is_file()]
+    if missing:
+        raise RuntimeError(f"Missing generated site files: {', '.join(missing)}")
+
+    manifest = json.loads((DOCS_DIR / "site-manifest.json").read_text(encoding="utf-8"))
+    if manifest.get("schema_version") != 1:
+        raise RuntimeError("Unsupported or missing site manifest schema_version.")
+    if not manifest.get("cases") or not manifest.get("total_reports"):
+        raise RuntimeError("Generated site manifest contains no reports.")
+
+    failures: list[str] = []
+    for html_path in DOCS_DIR.rglob("*.html"):
+        text = html_path.read_text(encoding="utf-8")
+        relative = html_path.relative_to(DOCS_DIR)
+        if '<html lang="ja">' not in text:
+            failures.append(f"{relative}: html language is not ja")
+        if "{{" in text or "{%" in text:
+            failures.append(f"{relative}: unresolved Jinja template marker")
+        if "#0d1117" in text or "Select a use case" in text:
+            failures.append(f"{relative}: legacy dashboard content remains")
+
+    if failures:
+        raise RuntimeError("Static site audit failed:\n- " + "\n- ".join(failures))
+
+    print(
+        "Static site audit passed: "
+        f"{manifest['total_reports']} reports / {len(manifest['cases'])} cases"
+    )
+
+
+if __name__ == "__main__":
+    audit()

--- a/web/build_static.py
+++ b/web/build_static.py
@@ -87,6 +87,18 @@ def rewrite_asset_links(markdown_text: str, rewrites: dict[str, str]) -> str:
     return updated
 
 
+def reset_docs_dir() -> None:
+    DOCS_DIR.mkdir(exist_ok=True)
+    preserved = {"CNAME", ".nojekyll"}
+    for path in DOCS_DIR.iterdir():
+        if path.name in preserved:
+            continue
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+
 def copy_site_assets() -> None:
     target = DOCS_DIR / "assets"
     target.mkdir(parents=True, exist_ok=True)
@@ -97,7 +109,7 @@ def copy_site_assets() -> None:
 
 def build() -> None:
     env = create_environment()
-    DOCS_DIR.mkdir(exist_ok=True)
+    reset_docs_dir()
     copy_site_assets()
 
     use_cases = get_use_cases()

--- a/web/build_static.py
+++ b/web/build_static.py
@@ -1,48 +1,176 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
 from pathlib import Path
+
 import markdown
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
+
+from catalog import describe_case, format_report_date
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 OUTPUT_DIR = PROJECT_ROOT / "output" / "use_cases"
 DOCS_DIR = PROJECT_ROOT / "docs"
 TEMPLATES_DIR = Path(__file__).parent / "templates"
-def get_use_cases():
-    return sorted([d.name for d in OUTPUT_DIR.iterdir() if d.is_dir()])
-def get_report_dates(use_case: str):
-    case_dir = OUTPUT_DIR / use_case
-    return (
-        sorted([d.name for d in case_dir.iterdir() if d.is_dir()], reverse=True)
-        if case_dir.exists()
-        else []
+STATIC_DIR = Path(__file__).parent / "static"
+
+
+def create_environment() -> Environment:
+    env = Environment(
+        loader=FileSystemLoader(TEMPLATES_DIR),
+        autoescape=select_autoescape(("html", "xml")),
+        undefined=StrictUndefined,
+        trim_blocks=True,
+        lstrip_blocks=True,
     )
-def get_report_content(use_case: str, date: str):
-    for f in (OUTPUT_DIR / use_case / date).glob("*.md"):
-        return f.read_text(encoding="utf-8")
-    return None
-def build():
-    env = Environment(loader=FileSystemLoader(TEMPLATES_DIR))
+    env.filters["report_date"] = format_report_date
+    return env
+
+
+def get_use_cases() -> list[str]:
+    if not OUTPUT_DIR.exists():
+        raise FileNotFoundError(f"Analysis output directory does not exist: {OUTPUT_DIR}")
+    return sorted(directory.name for directory in OUTPUT_DIR.iterdir() if directory.is_dir())
+
+
+def report_source(report_dir: Path) -> Path | None:
+    candidates = sorted(report_dir.glob("*.md"))
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+
+    preferred = [path for path in candidates if path.name in {"report.md", "analysis_report.md"}]
+    if len(preferred) == 1:
+        return preferred[0]
+
+    names = ", ".join(path.name for path in candidates)
+    raise RuntimeError(
+        f"Ambiguous report source in {report_dir}: {names}. "
+        "Keep one Markdown file or name the intended file report.md."
+    )
+
+
+def get_report_dates(use_case: str) -> list[str]:
+    case_dir = OUTPUT_DIR / use_case
+    dates = [
+        directory.name
+        for directory in case_dir.iterdir()
+        if directory.is_dir() and report_source(directory) is not None
+    ]
+    return sorted(dates, reverse=True)
+
+
+def copy_report_assets(report_dir: Path, case_docs_dir: Path, date: str) -> dict[str, str]:
+    rewrites: dict[str, str] = {}
+    for source in sorted(report_dir.rglob("*")):
+        if not source.is_file() or source.suffix.lower() == ".md":
+            continue
+        relative = source.relative_to(report_dir)
+        target = case_docs_dir / "assets" / date / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+        rewrites[relative.as_posix()] = f"assets/{date}/{relative.as_posix()}"
+    return rewrites
+
+
+def rewrite_asset_links(markdown_text: str, rewrites: dict[str, str]) -> str:
+    updated = markdown_text
+    for source, target in rewrites.items():
+        updated = updated.replace(f"]({source})", f"]({target})")
+        updated = updated.replace(f'src="{source}"', f'src="{target}"')
+        updated = updated.replace(f"src='{source}'", f"src='{target}'")
+        updated = updated.replace(f'href="{source}"', f'href="{target}"')
+        updated = updated.replace(f"href='{source}'", f"href='{target}'")
+    return updated
+
+
+def copy_site_assets() -> None:
+    target = DOCS_DIR / "assets"
+    target.mkdir(parents=True, exist_ok=True)
+    for source in sorted(STATIC_DIR.iterdir()):
+        if source.is_file():
+            shutil.copy2(source, target / source.name)
+
+
+def build() -> None:
+    env = create_environment()
     DOCS_DIR.mkdir(exist_ok=True)
+    copy_site_assets()
+
     use_cases = get_use_cases()
-    index_html = env.get_template("static_index.html").render(use_cases=use_cases)
+    cards: list[dict[str, object]] = []
+    report_index: list[dict[str, object]] = []
+
+    for slug in use_cases:
+        dates = get_report_dates(slug)
+        if not dates:
+            continue
+        meta = describe_case(slug)
+        cards.append(
+            {
+                **meta,
+                "report_count": len(dates),
+                "latest_date": dates[0],
+                "latest_date_label": format_report_date(dates[0]),
+            }
+        )
+        report_index.append({"slug": slug, "dates": dates, **meta})
+
+    if not cards:
+        raise RuntimeError("No publishable Markdown reports were found under output/use_cases.")
+
+    index_html = env.get_template("static_index.html").render(
+        cases=cards,
+        total_reports=sum(int(card["report_count"]) for card in cards),
+    )
     (DOCS_DIR / "index.html").write_text(index_html, encoding="utf-8")
-    for uc in use_cases:
-        uc_dir = DOCS_DIR / uc
-        uc_dir.mkdir(exist_ok=True)
-        dates = get_report_dates(uc)
+
+    for case in cards:
+        slug = str(case["slug"])
+        dates = get_report_dates(slug)
+        case_docs_dir = DOCS_DIR / slug
+        case_docs_dir.mkdir(exist_ok=True)
+
+        use_case_html = env.get_template("static_use_case.html").render(case=case, dates=dates)
+        (case_docs_dir / "index.html").write_text(use_case_html, encoding="utf-8")
+
         for date in dates:
-            content = get_report_content(uc, date)
-            if content:
-                html_content = markdown.markdown(
-                    content, extensions=["tables", "fenced_code"]
-                )
-                page = env.get_template("static_report.html").render(
-                    name=uc, date=date, content=html_content, dates=dates
-                )
-                (uc_dir / f"{date}.html").write_text(page, encoding="utf-8")
-        if dates:
-            (uc_dir / "index.html").write_text(
-                env.get_template("static_use_case.html").render(name=uc, dates=dates),
-                encoding="utf-8",
+            report_dir = OUTPUT_DIR / slug / date
+            source = report_source(report_dir)
+            if source is None:
+                continue
+            raw_markdown = source.read_text(encoding="utf-8")
+            rewrites = copy_report_assets(report_dir, case_docs_dir, date)
+            raw_markdown = rewrite_asset_links(raw_markdown, rewrites)
+            html_content = markdown.markdown(
+                raw_markdown,
+                extensions=["tables", "fenced_code", "sane_lists"],
+                output_format="html5",
             )
-    print(f"Built static site in {DOCS_DIR}")
+            report_html = env.get_template("static_report.html").render(
+                case=case,
+                date=date,
+                dates=dates,
+                content=html_content,
+                source_name=source.name,
+            )
+            (case_docs_dir / f"{date}.html").write_text(report_html, encoding="utf-8")
+
+    manifest = {
+        "schema_version": 1,
+        "source_revision": os.environ.get("GITHUB_SHA", "local"),
+        "cases": report_index,
+        "total_reports": sum(len(item["dates"]) for item in report_index),
+    }
+    (DOCS_DIR / "site-manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Built {manifest['total_reports']} reports across {len(cards)} cases in {DOCS_DIR}")
+
+
 if __name__ == "__main__":
     build()

--- a/web/catalog.py
+++ b/web/catalog.py
@@ -1,0 +1,98 @@
+"""Presentation metadata for CrewTrade research use cases.
+
+The analytical outputs remain the source of truth. This module only provides
+stable labels and explanations for the dashboard.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+CASE_CATALOG: Final[dict[str, dict[str, str]]] = {
+    "imura": {
+        "title": "ファンド・指数比較",
+        "category": "運用評価",
+        "summary": "ファンドと基準指数を同一期間・同一条件で比較し、リターンと下振れを分けて確認します。",
+        "question": "超過収益は、比較条件とリスクをそろえても残るか",
+        "accent": "blue",
+    },
+    "index_7_portfolio": {
+        "title": "7指数ポートフォリオ",
+        "category": "資産配分",
+        "summary": "複数指数の組み合わせを、収益率だけでなく分散効果と最大下落率から評価します。",
+        "question": "分散は、実際の下落局面で機能したか",
+        "accent": "lavender",
+    },
+    "index_etf_comparison": {
+        "title": "指数ETF比較",
+        "category": "商品比較",
+        "summary": "連動対象、通貨、コスト、値動きの差をそろえ、ETFを比較可能な形に整理します。",
+        "question": "同じ指数名でも、投資結果を分ける条件は何か",
+        "accent": "mint",
+    },
+    "legendary_investors": {
+        "title": "著名投資家リサーチ",
+        "category": "公開情報調査",
+        "summary": "公開資料と一次情報を起点に、投資判断の背景・再現可能性・制約を切り分けます。",
+        "question": "物語ではなく、検証可能な判断原則は何か",
+        "accent": "rose",
+    },
+    "oracle": {
+        "title": "個別企業・時系列予測",
+        "category": "予測実験",
+        "summary": "企業データと時系列モデルを扱い、予測値と実測値、学習期間と評価期間を分離します。",
+        "question": "予測はアウト・オブ・サンプルでも情報を持つか",
+        "accent": "apricot",
+    },
+    "precious_metals_spread": {
+        "title": "貴金属スプレッド",
+        "category": "相対価値",
+        "summary": "金属間の価格差と比率を追い、単純な価格上昇とは異なる相対変化を確認します。",
+        "question": "価格差は平均回帰か、構造変化か",
+        "accent": "lavender",
+    },
+    "securities_collateral_loan": {
+        "title": "証券担保ローン",
+        "category": "リスク管理",
+        "summary": "担保下落、金利、追証、強制売却の条件を明示し、資金調達の耐久力を検証します。",
+        "question": "どの下落率から意思決定の自由が失われるか",
+        "accent": "rose",
+    },
+    "semiconductors": {
+        "title": "半導体サイクル",
+        "category": "産業分析",
+        "summary": "需要、価格、設備投資、在庫、利益を分解し、循環要因と構造要因を区別します。",
+        "question": "利益成長は数量・価格・能力のどこから生じたか",
+        "accent": "blue",
+    },
+    "yield_spread": {
+        "title": "金利・イールドスプレッド",
+        "category": "マクロ",
+        "summary": "金利水準と期間差を追い、景気・流動性・期待インフレの変化を読み解きます。",
+        "question": "金利差の変化は、どの期待を反映しているか",
+        "accent": "mint",
+    },
+}
+
+
+def describe_case(slug: str) -> dict[str, str]:
+    """Return stable presentation metadata for a use case slug."""
+    if slug in CASE_CATALOG:
+        return {"slug": slug, **CASE_CATALOG[slug]}
+
+    title = slug.replace("_", " ").strip().title() or "名称未設定"
+    return {
+        "slug": slug,
+        "title": title,
+        "category": "未分類",
+        "summary": "分析出力は存在しますが、ダッシュボード用の説明はまだ登録されていません。",
+        "question": "対象、期間、計算条件をレポート本文で確認してください",
+        "accent": "neutral",
+    }
+
+
+def format_report_date(value: str) -> str:
+    """Format YYYYMMDD report folder names without guessing other formats."""
+    if len(value) == 8 and value.isdigit():
+        return f"{value[:4]}年{value[4:6]}月{value[6:]}日"
+    return value

--- a/web/static/site.css
+++ b/web/static/site.css
@@ -1,0 +1,191 @@
+:root {
+  --canvas: #fbfaf7;
+  --paper: rgba(255, 255, 255, 0.88);
+  --ink: #243653;
+  --muted: #66738b;
+  --line: rgba(70, 91, 126, 0.14);
+  --blue: #8fb5ec;
+  --lavender: #b9a8e6;
+  --rose: #efb4c1;
+  --mint: #b7dbc8;
+  --apricot: #f3cfaa;
+  --neutral: #cbd3df;
+  --radius: 22px;
+  --radius-small: 14px;
+  --shadow: 0 18px 50px rgba(76, 91, 125, 0.09);
+  --content: 1180px;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 12% 8%, rgba(143, 181, 236, 0.24), transparent 28rem),
+    radial-gradient(circle at 88% 3%, rgba(239, 180, 193, 0.2), transparent 24rem),
+    var(--canvas);
+  font-family: Inter, "Noto Sans JP", "Hiragino Sans", "Yu Gothic UI", system-ui, -apple-system, sans-serif;
+  line-height: 1.75;
+}
+
+a { color: inherit; text-decoration: none; }
+a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible {
+  outline: 3px solid rgba(143, 181, 236, 0.58);
+  outline-offset: 3px;
+}
+img { max-width: 100%; height: auto; }
+
+.shell { width: min(calc(100% - 32px), var(--content)); margin: 0 auto; }
+.site-header { padding: 24px 0 0; }
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 14px 18px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 10px 30px rgba(76, 91, 125, 0.06);
+  backdrop-filter: blur(16px);
+}
+.brand { display: flex; align-items: center; gap: 11px; font-weight: 800; letter-spacing: -0.02em; }
+.brand-mark {
+  display: grid; place-items: center; width: 34px; height: 34px; border-radius: 12px;
+  background: linear-gradient(145deg, var(--blue), var(--lavender));
+  color: #fff; font-size: 0.8rem; box-shadow: inset 0 0 0 1px rgba(255,255,255,.45);
+}
+.header-links { display: flex; gap: 8px; color: var(--muted); font-size: 0.88rem; }
+.header-links a { padding: 7px 11px; border-radius: 999px; }
+.header-links a:hover { background: rgba(143, 181, 236, 0.14); color: var(--ink); }
+
+main { padding: 54px 0 80px; }
+.hero { display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(280px, .55fr); gap: 36px; align-items: end; }
+.eyebrow { margin: 0 0 12px; color: #5577a7; font-size: .78rem; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+h1 { margin: 0; max-width: 15ch; font-size: clamp(2.7rem, 8vw, 5.8rem); line-height: .98; letter-spacing: -.065em; }
+.hero-copy { margin: 24px 0 0; max-width: 680px; color: var(--muted); font-size: clamp(1rem, 2vw, 1.15rem); }
+.hero-note, .notice {
+  border: 1px solid var(--line); border-radius: var(--radius); background: var(--paper); box-shadow: var(--shadow);
+}
+.hero-note { padding: 24px; }
+.hero-note strong { display: block; margin-bottom: 8px; font-size: 1rem; }
+.hero-note p { margin: 0; color: var(--muted); font-size: .92rem; }
+
+.metrics { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 28px; }
+.metric { padding: 8px 13px; border: 1px solid var(--line); border-radius: 999px; background: rgba(255,255,255,.62); font-size: .86rem; }
+.metric strong { margin-right: 4px; }
+
+.section { margin-top: 64px; }
+.section-heading { display: flex; justify-content: space-between; align-items: end; gap: 20px; margin-bottom: 22px; }
+.section-heading h2 { margin: 0; font-size: clamp(1.55rem, 3vw, 2.35rem); letter-spacing: -.04em; }
+.section-heading p { margin: 5px 0 0; color: var(--muted); }
+
+.toolbar { display: flex; align-items: center; gap: 12px; }
+.search {
+  width: min(340px, 70vw); padding: 12px 16px; color: var(--ink); background: rgba(255,255,255,.82);
+  border: 1px solid var(--line); border-radius: 999px; font: inherit;
+}
+.result-count { min-width: 4.5rem; color: var(--muted); font-size: .86rem; text-align: right; }
+
+.case-grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 16px; }
+.case-card {
+  --accent: var(--neutral);
+  grid-column: span 4; display: flex; flex-direction: column; min-height: 300px; padding: 24px;
+  border: 1px solid var(--line); border-radius: var(--radius); background: var(--paper); box-shadow: var(--shadow);
+  transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease;
+}
+.case-card:hover { transform: translateY(-4px); border-color: color-mix(in srgb, var(--accent) 70%, var(--line)); box-shadow: 0 24px 58px rgba(76, 91, 125, .13); }
+.case-card[data-accent="blue"] { --accent: var(--blue); }
+.case-card[data-accent="lavender"] { --accent: var(--lavender); }
+.case-card[data-accent="rose"] { --accent: var(--rose); }
+.case-card[data-accent="mint"] { --accent: var(--mint); }
+.case-card[data-accent="apricot"] { --accent: var(--apricot); }
+.case-card::before { content: ""; width: 52px; height: 7px; margin-bottom: 24px; border-radius: 999px; background: var(--accent); }
+.card-meta { display: flex; justify-content: space-between; gap: 12px; color: var(--muted); font-size: .78rem; }
+.case-card h3 { margin: 17px 0 8px; font-size: 1.35rem; letter-spacing: -.035em; }
+.case-card p { margin: 0; color: var(--muted); font-size: .92rem; }
+.card-question { margin-top: auto !important; padding-top: 22px; color: var(--ink) !important; font-weight: 700; }
+.card-question::before { content: "検証軸"; display: block; margin-bottom: 4px; color: var(--muted); font-size: .7rem; font-weight: 700; letter-spacing: .1em; }
+.card-arrow { display: inline-block; margin-top: 18px; font-weight: 800; }
+.case-card[hidden] { display: none; }
+
+.process-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+.process-step { padding: 22px; border: 1px solid var(--line); border-radius: var(--radius); background: rgba(255,255,255,.58); }
+.process-step span { display: inline-grid; place-items: center; width: 30px; height: 30px; border-radius: 10px; background: var(--ink); color: #fff; font-size: .78rem; font-weight: 800; }
+.process-step h3 { margin: 14px 0 5px; font-size: 1rem; }
+.process-step p { margin: 0; color: var(--muted); font-size: .88rem; }
+.notice { margin-top: 16px; padding: 22px 24px; color: var(--muted); }
+.notice strong { color: var(--ink); }
+
+.breadcrumbs { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 28px; color: var(--muted); font-size: .86rem; }
+.breadcrumbs a:hover { color: var(--ink); }
+.case-hero { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 28px; align-items: end; }
+.case-hero h1 { max-width: 18ch; font-size: clamp(2.4rem, 6vw, 4.8rem); }
+.case-summary { max-width: 700px; margin: 18px 0 0; color: var(--muted); }
+.question-box { max-width: 360px; padding: 20px; border-radius: var(--radius); background: color-mix(in srgb, var(--case-accent, var(--blue)) 22%, white); }
+.question-box small { display: block; margin-bottom: 5px; color: var(--muted); font-weight: 700; }
+
+.report-list { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+.report-link { padding: 20px; border: 1px solid var(--line); border-radius: var(--radius); background: var(--paper); box-shadow: var(--shadow); }
+.report-link:hover { border-color: var(--blue); transform: translateY(-2px); }
+.report-link strong { display: block; }
+.report-link span { color: var(--muted); font-size: .82rem; }
+.report-link.latest { background: linear-gradient(145deg, rgba(143,181,236,.25), rgba(255,255,255,.85)); }
+
+.report-layout { display: grid; grid-template-columns: 260px minmax(0, 1fr); gap: 28px; align-items: start; }
+.report-sidebar { position: sticky; top: 24px; padding: 18px; border: 1px solid var(--line); border-radius: var(--radius); background: rgba(255,255,255,.72); }
+.report-sidebar label { display: block; margin-bottom: 8px; color: var(--muted); font-size: .76rem; font-weight: 800; letter-spacing: .08em; }
+.report-sidebar select { width: 100%; padding: 11px 12px; color: var(--ink); background: #fff; border: 1px solid var(--line); border-radius: 12px; font: inherit; }
+.report-sidebar dl { margin: 22px 0 0; }
+.report-sidebar dt { color: var(--muted); font-size: .75rem; }
+.report-sidebar dd { margin: 2px 0 14px; font-size: .9rem; font-weight: 700; overflow-wrap: anywhere; }
+.report-panel { min-width: 0; }
+.report-heading { margin-bottom: 18px; padding: 24px 28px; border: 1px solid var(--line); border-radius: var(--radius); background: var(--paper); box-shadow: var(--shadow); }
+.report-heading h1 { max-width: none; font-size: clamp(2rem, 4vw, 3.4rem); }
+.report-heading p { margin: 10px 0 0; color: var(--muted); }
+.report-body { padding: clamp(22px, 5vw, 54px); border: 1px solid var(--line); border-radius: var(--radius); background: #fff; box-shadow: var(--shadow); overflow: hidden; }
+.report-body h1, .report-body h2, .report-body h3, .report-body h4 { line-height: 1.35; letter-spacing: -.025em; }
+.report-body h1 { max-width: none; font-size: 2rem; }
+.report-body h2 { margin-top: 2.4em; padding-bottom: .45em; border-bottom: 1px solid var(--line); font-size: 1.5rem; }
+.report-body h3 { margin-top: 2em; }
+.report-body p, .report-body li { color: #34445f; }
+.report-body a { color: #416da9; text-decoration: underline; text-underline-offset: 3px; }
+.report-body table { display: block; width: 100%; margin: 22px 0; border-collapse: collapse; overflow-x: auto; }
+.report-body th, .report-body td { padding: 11px 13px; border: 1px solid var(--line); text-align: left; white-space: nowrap; }
+.report-body th { background: rgba(143,181,236,.13); }
+.report-body pre { padding: 18px; border-radius: var(--radius-small); background: #f4f6fa; overflow-x: auto; }
+.report-body code { padding: .15em .35em; border-radius: 6px; background: #f1f3f7; }
+.report-body blockquote { margin: 22px 0; padding: 14px 20px; border-left: 5px solid var(--lavender); background: rgba(185,168,230,.12); }
+.report-body figure, .report-body img { border-radius: var(--radius-small); }
+
+.site-footer { padding: 0 0 46px; color: var(--muted); font-size: .82rem; }
+.footer-inner { display: flex; justify-content: space-between; gap: 18px; padding-top: 20px; border-top: 1px solid var(--line); }
+
+@media (max-width: 900px) {
+  .hero, .case-hero, .report-layout { grid-template-columns: 1fr; }
+  .case-card { grid-column: span 6; }
+  .report-sidebar { position: static; }
+  .report-list { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 620px) {
+  .shell { width: min(calc(100% - 22px), var(--content)); }
+  .site-header { padding-top: 10px; }
+  .header-inner { border-radius: 20px; align-items: flex-start; }
+  .header-links { flex-direction: column; align-items: flex-end; }
+  main { padding-top: 38px; }
+  h1 { font-size: 2.8rem; }
+  .section { margin-top: 48px; }
+  .section-heading { align-items: flex-start; flex-direction: column; }
+  .toolbar { width: 100%; }
+  .search { width: 100%; }
+  .case-card { grid-column: 1 / -1; min-height: 0; }
+  .process-grid, .report-list { grid-template-columns: 1fr; }
+  .report-heading, .report-body { padding: 20px; }
+  .footer-inner { flex-direction: column; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; }
+}

--- a/web/static/site.js
+++ b/web/static/site.js
@@ -1,0 +1,27 @@
+(() => {
+  const search = document.querySelector("[data-case-search]");
+  const cards = [...document.querySelectorAll("[data-case-card]")];
+  const count = document.querySelector("[data-result-count]");
+
+  if (search && cards.length) {
+    const filter = () => {
+      const query = search.value.trim().toLocaleLowerCase("ja");
+      let visible = 0;
+      cards.forEach((card) => {
+        const match = !query || card.dataset.search.includes(query);
+        card.hidden = !match;
+        visible += Number(match);
+      });
+      if (count) count.textContent = `${visible}件`;
+    };
+    search.addEventListener("input", filter);
+    filter();
+  }
+
+  const reportSelect = document.querySelector("[data-report-select]");
+  if (reportSelect) {
+    reportSelect.addEventListener("change", (event) => {
+      window.location.href = event.target.value;
+    });
+  }
+})();

--- a/web/templates/static_index.html
+++ b/web/templates/static_index.html
@@ -1,88 +1,86 @@
 <!DOCTYPE html>
-<html lang="en">
-
+<html lang="ja">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CrewTrade Dashboard</title>
-    <style>
-        :root {
-            --bg: #0d1117;
-            --surface: #161b22;
-            --border: #30363d;
-            --text: #e6edf3;
-            --muted: #8b949e;
-            --accent: #58a6ff
-        }
-
-        * {
-            box-sizing: border-box;
-            margin: 0;
-            padding: 0
-        }
-
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-            background: var(--bg);
-            color: var(--text);
-            line-height: 1.6;
-            padding: 2rem
-        }
-
-        h1,
-        h2,
-        h3 {
-            margin-bottom: 1rem
-        }
-
-        a {
-            color: var(--accent);
-            text-decoration: none
-        }
-
-        a:hover {
-            text-decoration: underline
-        }
-
-        .container {
-            max-width: 1200px;
-            margin: 0 auto
-        }
-
-        .card {
-            background: var(--surface);
-            border: 1px solid var(--border);
-            border-radius: 8px;
-            padding: 1.5rem;
-            margin-bottom: 1rem;
-            display: block
-        }
-
-        .card:hover {
-            border-color: var(--accent)
-        }
-
-        .grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-            gap: 1rem
-        }
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CrewTradeの金融調査・時系列分析レポートを、テーマ、更新日、検証軸から閲覧できる公開ワークスペースです。">
+  <title>CrewTrade | Financial Research Workspace</title>
+  <link rel="stylesheet" href="assets/site.css">
+  <script defer src="assets/site.js"></script>
 </head>
-
 <body>
-    <div class="container">
-        <h1>📊 CrewTrade Dashboard</h1>
-        <p style="color:var(--muted);margin-bottom:2rem">Select a use case to view reports.</p>
-        <div class="grid">
-            {% for uc in use_cases %}
-            <a href="{{ uc }}/index.html" class="card">
-                <h3>{{ uc.replace('_', ' ').title() }}</h3>
-                <p style="color:var(--muted)">View analysis reports</p>
-            </a>
-            {% endfor %}
-        </div>
+  <header class="site-header shell">
+    <div class="header-inner">
+      <a class="brand" href="index.html" aria-label="CrewTrade ホーム">
+        <span class="brand-mark">CT</span><span>CrewTrade</span>
+      </a>
+      <nav class="header-links" aria-label="外部リンク">
+        <a href="#research-map">調査テーマ</a>
+        <a href="https://github.com/KAFKA2306/CrewTrade">GitHub</a>
+      </nav>
     </div>
-</body>
+  </header>
 
+  <main class="shell">
+    <section class="hero">
+      <div>
+        <p class="eyebrow">Financial research workspace</p>
+        <h1>数字と解釈を、混ぜずに読む。</h1>
+        <p class="hero-copy">市場データ、計算結果、予測、文章による解釈を分離し、テーマごとの問いからレポートと根拠へ進むための公開ワークスペースです。</p>
+        <div class="metrics" aria-label="公開状況">
+          <span class="metric"><strong>{{ cases|length }}</strong>調査テーマ</span>
+          <span class="metric"><strong>{{ total_reports }}</strong>公開レポート</span>
+          <span class="metric">静的スナップショット</span>
+        </div>
+      </div>
+      <aside class="hero-note">
+        <strong>このサイトの前提</strong>
+        <p>掲載値は各レポートの作成日時点です。リアルタイム価格、投資助言、将来収益の保証ではありません。</p>
+      </aside>
+    </section>
+
+    <section class="section" id="research-map">
+      <div class="section-heading">
+        <div>
+          <p class="eyebrow">Research map</p>
+          <h2>問いから分析を選ぶ</h2>
+          <p>銘柄名の羅列ではなく、検証したい構造で整理しています。</p>
+        </div>
+        <div class="toolbar">
+          <input class="search" type="search" placeholder="テーマ・問いを検索" aria-label="調査テーマを検索" data-case-search>
+          <span class="result-count" data-result-count>{{ cases|length }}件</span>
+        </div>
+      </div>
+
+      <div class="case-grid">
+        {% for case in cases %}
+        <a class="case-card" href="{{ case.slug }}/index.html" data-case-card data-accent="{{ case.accent }}" data-search="{{ (case.title ~ ' ' ~ case.category ~ ' ' ~ case.summary ~ ' ' ~ case.question)|lower }}">
+          <div class="card-meta"><span>{{ case.category }}</span><span>{{ case.report_count }} reports</span></div>
+          <h3>{{ case.title }}</h3>
+          <p>{{ case.summary }}</p>
+          <p class="card-question">{{ case.question }}</p>
+          <span class="card-arrow">{{ case.latest_date_label }} →</span>
+        </a>
+        {% endfor %}
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-heading">
+        <div>
+          <p class="eyebrow">Reading protocol</p>
+          <h2>レポートの読み方</h2>
+        </div>
+      </div>
+      <div class="process-grid">
+        <div class="process-step"><span>01</span><h3>対象と期間</h3><p>銘柄、指数、通貨、取得日、比較期間を最初に固定します。</p></div>
+        <div class="process-step"><span>02</span><h3>計算条件</h3><p>配当、分割、手数料、税、欠損、インサンプル/OOSを確認します。</p></div>
+        <div class="process-step"><span>03</span><h3>解釈と限界</h3><p>定量結果、モデル予測、LLMの文章を別の証拠レイヤーとして読みます。</p></div>
+      </div>
+      <div class="notice"><strong>再現性:</strong> 公開ページはリポジトリ内の分析スナップショットから生成されます。生成器は曖昧な複数Markdownや出力欠損を成功扱いしません。</div>
+    </section>
+  </main>
+
+  <footer class="site-footer shell"><div class="footer-inner"><span>CrewTrade</span><span>Research, not recommendation.</span></div></footer>
+</body>
 </html>

--- a/web/templates/static_report.html
+++ b/web/templates/static_report.html
@@ -1,117 +1,38 @@
 <!DOCTYPE html>
-<html lang="en">
-
+<html lang="ja">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ name.replace('_', ' ').title() }} - {{ date }}</title>
-    <style>
-        :root {
-            --bg: #0d1117;
-            --surface: #161b22;
-            --border: #30363d;
-            --text: #e6edf3;
-            --muted: #8b949e;
-            --accent: #58a6ff
-        }
-
-        * {
-            box-sizing: border-box;
-            margin: 0;
-            padding: 0
-        }
-
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-            background: var(--bg);
-            color: var(--text);
-            line-height: 1.6;
-            padding: 2rem
-        }
-
-        h1,
-        h2,
-        h3,
-        h4 {
-            margin-top: 1.5rem;
-            margin-bottom: .5rem
-        }
-
-        a {
-            color: var(--accent);
-            text-decoration: none
-        }
-
-        .container {
-            max-width: 1000px;
-            margin: 0 auto
-        }
-
-        .report {
-            background: var(--surface);
-            border: 1px solid var(--border);
-            border-radius: 8px;
-            padding: 2rem;
-            margin-top: 1rem
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            margin: 1rem 0
-        }
-
-        th,
-        td {
-            border: 1px solid var(--border);
-            padding: .5rem;
-            text-align: left
-        }
-
-        th {
-            background: var(--bg)
-        }
-
-        code {
-            background: var(--bg);
-            padding: .2rem .4rem;
-            border-radius: 4px
-        }
-
-        pre {
-            background: var(--bg);
-            padding: 1rem;
-            border-radius: 6px;
-            overflow-x: auto
-        }
-
-        .nav {
-            margin-bottom: 1rem
-        }
-
-        .btn {
-            display: inline-block;
-            padding: .25rem .5rem;
-            background: var(--accent);
-            color: var(--bg);
-            border-radius: 4px;
-            margin: .125rem;
-            font-size: .8rem
-        }
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ case.title }} — {{ date|report_date }}の分析レポート。">
+  <title>{{ case.title }} — {{ date|report_date }} | CrewTrade</title>
+  <link rel="stylesheet" href="../assets/site.css">
+  <script defer src="../assets/site.js"></script>
 </head>
-
 <body>
-    <div class="container">
-        <div class="nav">
-            <a href="../index.html">← Dashboard</a> | <a href="index.html">{{ name.replace('_', ' ').title() }}</a>
-        </div>
-        <div class="nav">
-            {% for d in dates %}<a href="{{ d }}.html" class="btn{% if d == date %}" style="opacity:.5{% endif %}">{{ d
-                }}</a>{% endfor %}
-        </div>
-        <div class="report">{{ content | safe }}</div>
+  <header class="site-header shell">
+    <div class="header-inner">
+      <a class="brand" href="../index.html"><span class="brand-mark">CT</span><span>CrewTrade</span></a>
+      <nav class="header-links"><a href="index.html">レポート一覧</a><a href="https://github.com/KAFKA2306/CrewTrade">GitHub</a></nav>
     </div>
+  </header>
+  <main class="shell">
+    <nav class="breadcrumbs" aria-label="パンくず"><a href="../index.html">CrewTrade</a><span>/</span><a href="index.html">{{ case.title }}</a><span>/</span><span>{{ date|report_date }}</span></nav>
+    <div class="report-layout">
+      <aside class="report-sidebar">
+        <label for="report-date">スナップショット</label>
+        <select id="report-date" data-report-select>
+          {% for item in dates %}<option value="{{ item }}.html"{% if item == date %} selected{% endif %}>{{ item|report_date }}</option>{% endfor %}
+        </select>
+        <dl><dt>テーマ</dt><dd>{{ case.title }}</dd><dt>分類</dt><dd>{{ case.category }}</dd><dt>生成元</dt><dd>{{ source_name }}</dd></dl>
+        <a class="card-arrow" href="index.html">← 一覧へ戻る</a>
+      </aside>
+      <div class="report-panel">
+        <header class="report-heading"><p class="eyebrow">Analysis snapshot</p><h1>{{ case.title }}</h1><p>{{ date|report_date }} · 掲載値は作成時点のスナップショットです。</p></header>
+        <article class="report-body">{{ content | safe }}</article>
+        <div class="notice"><strong>解釈上の注意:</strong> 過去の成績とモデル予測は将来の収益を保証しません。本文の対象期間、比較条件、欠損処理、評価区間を優先してください。</div>
+      </div>
+    </div>
+  </main>
+  <footer class="site-footer shell"><div class="footer-inner"><span>CrewTrade / {{ case.title }}</span><span>{{ date|report_date }}</span></div></footer>
 </body>
-
 </html>

--- a/web/templates/static_use_case.html
+++ b/web/templates/static_use_case.html
@@ -1,70 +1,41 @@
 <!DOCTYPE html>
-<html lang="en">
-
+<html lang="ja">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ name.replace('_', ' ').title() }} - CrewTrade</title>
-    <style>
-        :root {
-            --bg: #0d1117;
-            --surface: #161b22;
-            --border: #30363d;
-            --text: #e6edf3;
-            --muted: #8b949e;
-            --accent: #58a6ff
-        }
-
-        * {
-            box-sizing: border-box;
-            margin: 0;
-            padding: 0
-        }
-
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-            background: var(--bg);
-            color: var(--text);
-            line-height: 1.6;
-            padding: 2rem
-        }
-
-        h1,
-        h2,
-        h3 {
-            margin-bottom: 1rem
-        }
-
-        a {
-            color: var(--accent);
-            text-decoration: none
-        }
-
-        .container {
-            max-width: 1200px;
-            margin: 0 auto
-        }
-
-        .btn {
-            display: inline-block;
-            padding: .5rem 1rem;
-            background: var(--accent);
-            color: var(--bg);
-            border-radius: 6px;
-            margin: .25rem
-        }
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ case.title }}の公開分析レポート一覧。">
+  <title>{{ case.title }} | CrewTrade</title>
+  <link rel="stylesheet" href="../assets/site.css">
 </head>
-
-<body>
-    <div class="container">
-        <h1>{{ name.replace('_', ' ').title() }}</h1>
-        <p><a href="../index.html">← Back to Dashboard</a></p>
-        <h3>Reports</h3>
-        {% for date in dates %}
-        <a href="{{ date }}.html" class="btn">{{ date }}</a>
-        {% endfor %}
+<body style="--case-accent: var(--{{ case.accent }});">
+  <header class="site-header shell">
+    <div class="header-inner">
+      <a class="brand" href="../index.html"><span class="brand-mark">CT</span><span>CrewTrade</span></a>
+      <nav class="header-links"><a href="../index.html">全テーマ</a><a href="https://github.com/KAFKA2306/CrewTrade">GitHub</a></nav>
     </div>
-</body>
+  </header>
+  <main class="shell">
+    <nav class="breadcrumbs" aria-label="パンくず"><a href="../index.html">CrewTrade</a><span>/</span><span>{{ case.title }}</span></nav>
+    <section class="case-hero">
+      <div>
+        <p class="eyebrow">{{ case.category }}</p>
+        <h1>{{ case.title }}</h1>
+        <p class="case-summary">{{ case.summary }}</p>
+        <div class="metrics"><span class="metric"><strong>{{ dates|length }}</strong>公開レポート</span><span class="metric">最新 {{ dates[0]|report_date }}</span></div>
+      </div>
+      <aside class="question-box"><small>この分析の検証軸</small><strong>{{ case.question }}</strong></aside>
+    </section>
 
+    <section class="section">
+      <div class="section-heading"><div><p class="eyebrow">Reports</p><h2>分析スナップショット</h2><p>作成日ごとの条件と結論の変化を追えます。</p></div></div>
+      <div class="report-list">
+        {% for date in dates %}
+        <a class="report-link{% if loop.first %} latest{% endif %}" href="{{ date }}.html"><strong>{{ date|report_date }}</strong><span>{% if loop.first %}最新レポート{% else %}過去スナップショット{% endif %}</span></a>
+        {% endfor %}
+      </div>
+      <div class="notice"><strong>注意:</strong> 日付はレポートのスナップショット識別子です。本文でデータ取得日と対象期間を確認してください。</div>
+    </section>
+  </main>
+  <footer class="site-footer shell"><div class="footer-inner"><span>CrewTrade / {{ case.title }}</span><span>Research, not recommendation.</span></div></footer>
+</body>
 </html>


### PR DESCRIPTION
## 変更内容

- GitHub Pagesを暗色の単純なレポート一覧から、問い・分類・更新日を中心にした日本語の調査ワークスペースへ再設計
- ユーザー共通のパステル配色とレスポンシブな共通デザインシステムを追加
- 9つの既存ユースケースに表示名、分類、説明、検証軸を定義
- テーマ検索、レポート日付切替、モバイル表示を追加
- Markdown、画像、添付物を日付別に公開し、同名アセットの上書きを防止
- `site-manifest.json` を生成し、公開テーマ・レポート日付・ソースリビジョンを記録
- 旧生成物を毎回削除して再生成し、`CNAME` と `.nojekyll` のみ保持
- 曖昧なMarkdown選択、出力欠損、旧UI残存、Jinja未解決を監査で拒否
- READMEを現行構造、公開ロジック、検証方針に合わせて更新

## 目的

市場データ、定量計算、予測、LLMによる解釈を混同せず、利用者が「何を検証する分析か」を先に判断してから根拠へ進める情報設計にするためです。

## 検証

- Python compileall: PASS
- サンプル2テーマの静的生成: PASS
- 日付別画像コピーとリンク書換: PASS
- 旧HTML削除と CNAME 保持: PASS
- 静的サイト監査: PASS
