### PR TITLE
GitHub Pages公開基盤を現行Actionsへ更新

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,8 +18,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.11"
+          enable-cache: true
       - name: Install dependencies
         run: uv sync
       - name: Compile web code
@@ -28,7 +35,8 @@ jobs:
         run: uv run python web/build_static.py
       - name: Audit generated site
         run: uv run python web/audit_static.py
-      - uses: actions/upload-pages-artifact@v3
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs
 
@@ -39,5 +47,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - id: deployment
+      - name: Deploy to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 変更

- `actions/checkout@v6` へ更新
- `actions/configure-pages@v5` を追加
- `actions/upload-pages-artifact@v4` へ更新
- `actions/deploy-pages@v4` を維持
- `astral-sh/setup-uv` を公式推奨の v8.1.0 コミットへ固定
- Python 3.11 と uv キャッシュを明示

## 根拠

GitHub Pagesの公式カスタムワークフローとAstralの公式GitHub Actionsガイドに合わせた更新です。既存のcompile、build、audit処理は変更していません。
