### PR TITLE
Pagesをマージ前監査へ拡張

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -11,8 +13,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: pages-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -41,6 +43,7 @@ jobs:
           path: docs
 
   deploy:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/web/audit_static.py
+++ b/web/audit_static.py
@@ -1,10 +1,49 @@
 from __future__ import annotations
 
 import json
+from html.parser import HTMLParser
 from pathlib import Path
+from urllib.parse import unquote, urlsplit
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DOCS_DIR = PROJECT_ROOT / "docs"
+
+
+class LocalReferenceParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.references: list[tuple[str, str]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = dict(attrs)
+        if tag in {"a", "link"} and values.get("href"):
+            self.references.append(("href", values["href"] or ""))
+        if tag in {"img", "script", "source"} and values.get("src"):
+            self.references.append(("src", values["src"] or ""))
+
+
+def resolve_local_reference(html_path: Path, reference: str) -> Path | None:
+    parsed = urlsplit(reference)
+    if parsed.scheme or parsed.netloc or reference.startswith(("#", "mailto:", "tel:", "data:")):
+        return None
+
+    path_text = unquote(parsed.path)
+    if not path_text:
+        return None
+
+    if path_text.startswith("/"):
+        candidate = DOCS_DIR / path_text.lstrip("/")
+    else:
+        candidate = html_path.parent / path_text
+
+    candidate = candidate.resolve()
+    docs_root = DOCS_DIR.resolve()
+    if docs_root not in candidate.parents and candidate != docs_root:
+        raise RuntimeError(f"Reference escapes docs root: {reference}")
+
+    if candidate.is_dir():
+        candidate = candidate / "index.html"
+    return candidate
 
 
 def audit() -> None:
@@ -25,7 +64,34 @@ def audit() -> None:
         raise RuntimeError("Generated site manifest contains no reports.")
 
     failures: list[str] = []
-    for html_path in DOCS_DIR.rglob("*.html"):
+    manifest_report_count = 0
+    for case in manifest["cases"]:
+        slug = case.get("slug")
+        dates = case.get("dates", [])
+        if not slug or not dates:
+            failures.append(f"manifest: invalid case entry {case!r}")
+            continue
+        if not (DOCS_DIR / slug / "index.html").is_file():
+            failures.append(f"manifest: missing {slug}/index.html")
+        for date in dates:
+            manifest_report_count += 1
+            if not (DOCS_DIR / slug / f"{date}.html").is_file():
+                failures.append(f"manifest: missing {slug}/{date}.html")
+
+    if manifest_report_count != manifest["total_reports"]:
+        failures.append(
+            "manifest: total_reports does not match report entries "
+            f"({manifest['total_reports']} != {manifest_report_count})"
+        )
+
+    html_files = sorted(DOCS_DIR.rglob("*.html"))
+    if len(html_files) != manifest_report_count + len(manifest["cases"]) + 1:
+        failures.append(
+            "generated HTML count does not match manifest "
+            f"({len(html_files)} files)"
+        )
+
+    for html_path in html_files:
         text = html_path.read_text(encoding="utf-8")
         relative = html_path.relative_to(DOCS_DIR)
         if '<html lang="ja">' not in text:
@@ -35,12 +101,27 @@ def audit() -> None:
         if "#0d1117" in text or "Select a use case" in text:
             failures.append(f"{relative}: legacy dashboard content remains")
 
+        parser = LocalReferenceParser()
+        parser.feed(text)
+        for attribute, reference in parser.references:
+            try:
+                target = resolve_local_reference(html_path, reference)
+            except RuntimeError as error:
+                failures.append(f"{relative}: {error}")
+                continue
+            if target is not None and not target.is_file():
+                failures.append(
+                    f"{relative}: broken local {attribute}={reference!r} "
+                    f"-> {target.relative_to(DOCS_DIR.resolve())}"
+                )
+
     if failures:
         raise RuntimeError("Static site audit failed:\n- " + "\n- ".join(failures))
 
     print(
         "Static site audit passed: "
-        f"{manifest['total_reports']} reports / {len(manifest['cases'])} cases"
+        f"{manifest['total_reports']} reports / {len(manifest['cases'])} cases / "
+        f"{len(html_files)} HTML files"
     )
 
 


### PR DESCRIPTION
## 変更

- `pull_request` でもPagesのcompile・build・auditを実行
- deployは `push` と手動実行時だけに制限
- concurrencyをイベントとref単位に分離
- manifest記載件数と生成HTML数の整合性を検査
- manifestに記載されたテーマ・日付ページの存在を検査
- HTML内のローカル `href` / `src` を解決し、リンク切れとdocs外参照を拒否

## 監査目的

Pagesの不具合をmainへマージした後ではなく、PR段階で検出できる状態にします。外部URLはネットワーク依存のため監査対象外とし、リポジトリから生成される内部構造を決定論的に検査します。
