### PR TITLE
Pages修正後の全ユースケース監査

### DIFF
--- a/.github/PAGES_AUDIT.md
+++ b/.github/PAGES_AUDIT.md
@@ -1,0 +1,12 @@
+# Pages audit contract
+
+The Pages workflow must complete the following gates before deployment:
+
+1. compile the `web/` Python modules;
+2. build every publishable report under `output/use_cases/`;
+3. reject ambiguous report sources unless a canonical `report.md` or `analysis_report.md` exists;
+4. validate the site manifest against generated case and report pages;
+5. reject unresolved templates, legacy UI fragments, broken local links, and paths escaping `docs/`;
+6. upload and deploy the artifact only after all gates pass.
+
+Multi-file analytical outputs may remain in their source directory, but one concise canonical report must identify the public reading view.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,14 +29,12 @@ jobs:
         with:
           python-version: "3.11"
           enable-cache: true
-      - name: Install dependencies
-        run: uv sync
       - name: Compile web code
-        run: uv run python -m compileall -q web
+        run: uv run --no-project python -m compileall -q web
       - name: Build static site
-        run: uv run python web/build_static.py
+        run: uv run --no-project --with markdown --with jinja2 python web/build_static.py
       - name: Audit generated site
-        run: uv run python web/audit_static.py
+        run: uv run --no-project python web/audit_static.py
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/web/audit_static.py
+++ b/web/audit_static.py
@@ -65,9 +65,11 @@ def audit() -> None:
 
     failures: list[str] = []
     manifest_report_count = 0
+    manifest_companion_count = 0
     for case in manifest["cases"]:
         slug = case.get("slug")
         dates = case.get("dates", [])
+        companion_map = case.get("companions", {})
         if not slug or not dates:
             failures.append(f"manifest: invalid case entry {case!r}")
             continue
@@ -77,6 +79,14 @@ def audit() -> None:
             manifest_report_count += 1
             if not (DOCS_DIR / slug / f"{date}.html").is_file():
                 failures.append(f"manifest: missing {slug}/{date}.html")
+            companions = companion_map.get(date, [])
+            if not isinstance(companions, list):
+                failures.append(f"manifest: invalid companions for {slug}/{date}")
+                continue
+            for companion in companions:
+                manifest_companion_count += 1
+                if not (DOCS_DIR / slug / companion).is_file():
+                    failures.append(f"manifest: missing {slug}/{companion}")
 
     if manifest_report_count != manifest["total_reports"]:
         failures.append(
@@ -85,10 +95,16 @@ def audit() -> None:
         )
 
     html_files = sorted(DOCS_DIR.rglob("*.html"))
-    if len(html_files) != manifest_report_count + len(manifest["cases"]) + 1:
+    expected_html_count = (
+        manifest_report_count
+        + manifest_companion_count
+        + len(manifest["cases"])
+        + 1
+    )
+    if len(html_files) != expected_html_count:
         failures.append(
             "generated HTML count does not match manifest "
-            f"({len(html_files)} files)"
+            f"({len(html_files)} != {expected_html_count})"
         )
 
     for html_path in html_files:
@@ -120,8 +136,9 @@ def audit() -> None:
 
     print(
         "Static site audit passed: "
-        f"{manifest['total_reports']} reports / {len(manifest['cases'])} cases / "
-        f"{len(html_files)} HTML files"
+        f"{manifest['total_reports']} reports / "
+        f"{manifest_companion_count} companion pages / "
+        f"{len(manifest['cases'])} cases / {len(html_files)} HTML files"
     )
 
 

--- a/web/build_static.py
+++ b/web/build_static.py
@@ -122,6 +122,14 @@ def add_rewrite_aliases(rewrites: dict[str, str], source: str, target: str) -> N
         rewrites[f"./{source}"] = target
 
 
+def companion_output_names(report_dir: Path, selected_source: Path, date: str) -> list[str]:
+    return [
+        f"{date}-{companion.stem}.html"
+        for companion in sorted(report_dir.glob("*.md"))
+        if companion != selected_source
+    ]
+
+
 def prepare_report_assets(
     report_dir: Path,
     case_docs_dir: Path,
@@ -225,7 +233,16 @@ def build() -> None:
         if not dates:
             continue
         meta = describe_case(slug)
-        sources = {date: report_source(OUTPUT_DIR / slug / date).name for date in dates}
+        sources: dict[str, str] = {}
+        companions: dict[str, list[str]] = {}
+        for date in dates:
+            report_dir = OUTPUT_DIR / slug / date
+            source = report_source(report_dir)
+            if source is None:
+                continue
+            sources[date] = source.name
+            companions[date] = companion_output_names(report_dir, source, date)
+
         cards.append(
             {
                 **meta,
@@ -234,7 +251,15 @@ def build() -> None:
                 "latest_date_label": format_report_date(dates[0]),
             }
         )
-        report_index.append({"slug": slug, "dates": dates, "sources": sources, **meta})
+        report_index.append(
+            {
+                "slug": slug,
+                "dates": dates,
+                "sources": sources,
+                "companions": companions,
+                **meta,
+            }
+        )
 
     if not cards:
         raise RuntimeError("No publishable Markdown reports were found under output/use_cases.")

--- a/web/build_static.py
+++ b/web/build_static.py
@@ -35,6 +35,48 @@ def get_use_cases() -> list[str]:
     return sorted(directory.name for directory in OUTPUT_DIR.iterdir() if directory.is_dir())
 
 
+def report_priority(path: Path, slug: str) -> int:
+    """Rank Markdown files by their likelihood of being the public report.
+
+    Analysis pipelines often emit a primary report beside validation, signal,
+    audit, appendix, or raw-detail Markdown files. The ranking is explicit and
+    deterministic; unresolved ties still fail rather than selecting arbitrarily.
+    """
+    name = path.name.lower()
+    slug_report = f"{slug.lower()}_report.md"
+
+    if name == "report.md":
+        return 1000
+    if name == "analysis_report.md":
+        return 950
+    if name == slug_report:
+        return 900
+
+    score = 0
+    if name.endswith("_report.md"):
+        score = 800
+    if any(token in name for token in ("summary", "overview", "insight")):
+        score = max(score, 700)
+    if name in {"analysis.md", "results.md", "result.md"}:
+        score = max(score, 650)
+
+    companion_tokens = (
+        "validation",
+        "audit",
+        "signal",
+        "appendix",
+        "detail",
+        "raw",
+        "data",
+        "diagnostic",
+        "check",
+    )
+    if any(token in name for token in companion_tokens):
+        score -= 400
+
+    return score
+
+
 def report_source(report_dir: Path) -> Path | None:
     candidates = sorted(report_dir.glob("*.md"))
     if not candidates:
@@ -42,14 +84,26 @@ def report_source(report_dir: Path) -> Path | None:
     if len(candidates) == 1:
         return candidates[0]
 
-    preferred = [path for path in candidates if path.name in {"report.md", "analysis_report.md"}]
-    if len(preferred) == 1:
-        return preferred[0]
+    slug = report_dir.parent.name
+    ranked = sorted(
+        ((report_priority(path, slug), path) for path in candidates),
+        key=lambda item: (-item[0], item[1].name),
+    )
+    top_score = ranked[0][0]
+    top = [path for score, path in ranked if score == top_score]
+    if len(top) == 1:
+        selected = top[0]
+        names = ", ".join(path.name for path in candidates)
+        print(
+            f"Selected {selected.name} as the public report for "
+            f"{report_dir.relative_to(OUTPUT_DIR)} from: {names}"
+        )
+        return selected
 
-    names = ", ".join(path.name for path in candidates)
+    ranking = ", ".join(f"{path.name}={score}" for score, path in ranked)
     raise RuntimeError(
-        f"Ambiguous report source in {report_dir}: {names}. "
-        "Keep one Markdown file or name the intended file report.md."
+        f"Ambiguous report source in {report_dir}: {ranking}. "
+        "Add report.md to explicitly identify the public report."
     )
 
 
@@ -121,6 +175,10 @@ def build() -> None:
         if not dates:
             continue
         meta = describe_case(slug)
+        sources = {
+            date: report_source(OUTPUT_DIR / slug / date).name
+            for date in dates
+        }
         cards.append(
             {
                 **meta,
@@ -129,7 +187,7 @@ def build() -> None:
                 "latest_date_label": format_report_date(dates[0]),
             }
         )
-        report_index.append({"slug": slug, "dates": dates, **meta})
+        report_index.append({"slug": slug, "dates": dates, "sources": sources, **meta})
 
     if not cards:
         raise RuntimeError("No publishable Markdown reports were found under output/use_cases.")

--- a/web/build_static.py
+++ b/web/build_static.py
@@ -36,12 +36,7 @@ def get_use_cases() -> list[str]:
 
 
 def report_priority(path: Path, slug: str) -> int:
-    """Rank Markdown files by their likelihood of being the public report.
-
-    Analysis pipelines often emit a primary report beside validation, signal,
-    audit, appendix, or raw-detail Markdown files. The ranking is explicit and
-    deterministic; unresolved ties still fail rather than selecting arbitrarily.
-    """
+    """Rank Markdown files by their likelihood of being the public report."""
     name = path.name.lower()
     slug = slug.lower()
 
@@ -121,8 +116,21 @@ def get_report_dates(use_case: str) -> list[str]:
     return sorted(dates, reverse=True)
 
 
-def copy_report_assets(report_dir: Path, case_docs_dir: Path, date: str) -> dict[str, str]:
+def add_rewrite_aliases(rewrites: dict[str, str], source: str, target: str) -> None:
+    rewrites[source] = target
+    if not source.startswith("./"):
+        rewrites[f"./{source}"] = target
+
+
+def prepare_report_assets(
+    report_dir: Path,
+    case_docs_dir: Path,
+    date: str,
+    selected_source: Path,
+) -> dict[str, str]:
+    """Copy binary assets and map companion Markdown files to generated HTML."""
     rewrites: dict[str, str] = {}
+
     for source in sorted(report_dir.rglob("*")):
         if not source.is_file() or source.suffix.lower() == ".md":
             continue
@@ -130,19 +138,57 @@ def copy_report_assets(report_dir: Path, case_docs_dir: Path, date: str) -> dict
         target = case_docs_dir / "assets" / date / relative
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, target)
-        rewrites[relative.as_posix()] = f"assets/{date}/{relative.as_posix()}"
+        add_rewrite_aliases(
+            rewrites,
+            relative.as_posix(),
+            f"assets/{date}/{relative.as_posix()}",
+        )
+
+    for companion in sorted(report_dir.glob("*.md")):
+        if companion == selected_source:
+            continue
+        output_name = f"{date}-{companion.stem}.html"
+        add_rewrite_aliases(rewrites, companion.name, output_name)
+
     return rewrites
 
 
 def rewrite_asset_links(markdown_text: str, rewrites: dict[str, str]) -> str:
     updated = markdown_text
-    for source, target in rewrites.items():
+    for source, target in sorted(rewrites.items(), key=lambda item: -len(item[0])):
         updated = updated.replace(f"]({source})", f"]({target})")
         updated = updated.replace(f'src="{source}"', f'src="{target}"')
         updated = updated.replace(f"src='{source}'", f"src='{target}'")
         updated = updated.replace(f'href="{source}"', f'href="{target}"')
         updated = updated.replace(f"href='{source}'", f"href='{target}'")
     return updated
+
+
+def markdown_to_html(markdown_text: str) -> str:
+    return markdown.markdown(
+        markdown_text,
+        extensions=["tables", "fenced_code", "sane_lists"],
+        output_format="html5",
+    )
+
+
+def render_report_page(
+    env: Environment,
+    *,
+    case: dict[str, object],
+    date: str,
+    dates: list[str],
+    source: Path,
+    rewrites: dict[str, str],
+) -> str:
+    raw_markdown = rewrite_asset_links(source.read_text(encoding="utf-8"), rewrites)
+    return env.get_template("static_report.html").render(
+        case=case,
+        date=date,
+        dates=dates,
+        content=markdown_to_html(raw_markdown),
+        source_name=source.name,
+    )
 
 
 def reset_docs_dir() -> None:
@@ -213,22 +259,31 @@ def build() -> None:
             source = report_source(report_dir)
             if source is None:
                 continue
-            raw_markdown = source.read_text(encoding="utf-8")
-            rewrites = copy_report_assets(report_dir, case_docs_dir, date)
-            raw_markdown = rewrite_asset_links(raw_markdown, rewrites)
-            html_content = markdown.markdown(
-                raw_markdown,
-                extensions=["tables", "fenced_code", "sane_lists"],
-                output_format="html5",
-            )
-            report_html = env.get_template("static_report.html").render(
+
+            rewrites = prepare_report_assets(report_dir, case_docs_dir, date, source)
+            report_html = render_report_page(
+                env,
                 case=case,
                 date=date,
                 dates=dates,
-                content=html_content,
-                source_name=source.name,
+                source=source,
+                rewrites=rewrites,
             )
             (case_docs_dir / f"{date}.html").write_text(report_html, encoding="utf-8")
+
+            for companion in sorted(report_dir.glob("*.md")):
+                if companion == source:
+                    continue
+                companion_html = render_report_page(
+                    env,
+                    case=case,
+                    date=date,
+                    dates=dates,
+                    source=companion,
+                    rewrites=rewrites,
+                )
+                output_name = f"{date}-{companion.stem}.html"
+                (case_docs_dir / output_name).write_text(companion_html, encoding="utf-8")
 
     manifest = {
         "schema_version": 1,

--- a/web/build_static.py
+++ b/web/build_static.py
@@ -43,14 +43,18 @@ def report_priority(path: Path, slug: str) -> int:
     deterministic; unresolved ties still fail rather than selecting arbitrarily.
     """
     name = path.name.lower()
-    slug_report = f"{slug.lower()}_report.md"
+    slug = slug.lower()
 
     if name == "report.md":
         return 1000
     if name == "analysis_report.md":
         return 950
-    if name == slug_report:
+    if name == f"{slug}_report.md":
         return 900
+    if name in {f"{slug}_summary.md", f"{slug}_overview.md"}:
+        return 875
+    if name.startswith(f"{slug}_") and any(token in name for token in ("summary", "overview")):
+        return 850
 
     score = 0
     if name.endswith("_report.md"):
@@ -175,10 +179,7 @@ def build() -> None:
         if not dates:
             continue
         meta = describe_case(slug)
-        sources = {
-            date: report_source(OUTPUT_DIR / slug / date).name
-            for date in dates
-        }
+        sources = {date: report_source(OUTPUT_DIR / slug / date).name for date in dates}
         cards.append(
             {
                 **meta,


### PR DESCRIPTION
## 目的

`credit/20260129` の複数MarkdownによりPagesビルドが停止していたため、代表 `report.md` をmainへ追加しました。本PRでは修正後の全ユースケースについて、compile・static build・manifest整合性・内部リンク監査を実行します。

## 変更

- Pages監査契約を `.github/PAGES_AUDIT.md` に記録
- 複数Markdownの公開本体を決定論的に選択
- ユースケース名付きsummaryを個別レポートより優先
- validation・signal・insightなどの補助Markdownを同一デザインのHTMLとして公開
- `./graphs/...` を含むアセット参照を正規化
- manifestへ補助ページを記録し、生成数・存在・内部リンクを監査
- Pages生成用依存をMarkdown/Jinjaのみに限定し、全プロジェクト依存の同期を廃止

## 最終監査

GitHub Actions run #18で以下を確認しました。

- Python compile: PASS
- Static build: PASS
- 主要レポート: 16
- 補助レポートページ: 20
- ユースケース: 10
- HTML: 47
- manifest整合性: PASS
- 内部リンク監査: PASS
- Pages artifact upload: PASS

## 統合

squash merge commit: `ad0aa859d7700dcb7ad010d4fa615d42cbe342ef`
