### PR TITLE
Pagesにテーブル表示を追加

### DIFF
--- a/web/audit_static.py
+++ b/web/audit_static.py
@@ -50,6 +50,7 @@ def audit() -> None:
     required = [
         DOCS_DIR / "index.html",
         DOCS_DIR / "assets" / "site.css",
+        DOCS_DIR / "assets" / "table.css",
         DOCS_DIR / "assets" / "site.js",
         DOCS_DIR / "site-manifest.json",
     ]
@@ -64,6 +65,19 @@ def audit() -> None:
         raise RuntimeError("Generated site manifest contains no reports.")
 
     failures: list[str] = []
+    index_text = (DOCS_DIR / "index.html").read_text(encoding="utf-8")
+    required_index_markers = {
+        'data-case-view="table"': "table view container",
+        'data-case-view="cards"': "card view container",
+        'data-view-button="table"': "table view button",
+        'data-view-button="cards"': "card view button",
+        'class="case-table"': "research table",
+        'href="assets/table.css"': "table stylesheet",
+    }
+    for marker, label in required_index_markers.items():
+        if marker not in index_text:
+            failures.append(f"index.html: missing {label}")
+
     manifest_report_count = 0
     manifest_companion_count = 0
     for case in manifest["cases"]:
@@ -73,8 +87,17 @@ def audit() -> None:
         if not slug or not dates:
             failures.append(f"manifest: invalid case entry {case!r}")
             continue
-        if not (DOCS_DIR / slug / "index.html").is_file():
+
+        case_index = DOCS_DIR / slug / "index.html"
+        if not case_index.is_file():
             failures.append(f"manifest: missing {slug}/index.html")
+        else:
+            case_text = case_index.read_text(encoding="utf-8")
+            if 'class="report-table"' not in case_text:
+                failures.append(f"{slug}/index.html: missing report table")
+            if 'href="../assets/table.css"' not in case_text:
+                failures.append(f"{slug}/index.html: missing table stylesheet")
+
         for date in dates:
             manifest_report_count += 1
             if not (DOCS_DIR / slug / f"{date}.html").is_file():
@@ -138,7 +161,8 @@ def audit() -> None:
         "Static site audit passed: "
         f"{manifest['total_reports']} reports / "
         f"{manifest_companion_count} companion pages / "
-        f"{len(manifest['cases'])} cases / {len(html_files)} HTML files"
+        f"{len(manifest['cases'])} cases / {len(html_files)} HTML files / "
+        "table views enabled"
     )
 
 

--- a/web/static/site.js
+++ b/web/static/site.js
@@ -1,22 +1,79 @@
 (() => {
   const search = document.querySelector("[data-case-search]");
-  const cards = [...document.querySelectorAll("[data-case-card]")];
+  const caseItems = [...document.querySelectorAll("[data-case-item]")];
   const count = document.querySelector("[data-result-count]");
+  const viewButtons = [...document.querySelectorAll("[data-view-button]")];
+  const views = [...document.querySelectorAll("[data-case-view]")];
 
-  if (search && cards.length) {
-    const filter = () => {
-      const query = search.value.trim().toLocaleLowerCase("ja");
-      let visible = 0;
-      cards.forEach((card) => {
-        const match = !query || card.dataset.search.includes(query);
-        card.hidden = !match;
-        visible += Number(match);
+  const caseGroups = new Map();
+  caseItems.forEach((item) => {
+    const slug = item.dataset.caseSlug;
+    if (!slug) return;
+    if (!caseGroups.has(slug)) caseGroups.set(slug, []);
+    caseGroups.get(slug).push(item);
+  });
+
+  const filterCases = () => {
+    if (!caseGroups.size) return;
+    const query = search?.value.trim().toLocaleLowerCase("ja") ?? "";
+    let visible = 0;
+
+    caseGroups.forEach((items) => {
+      const searchable = items[0]?.dataset.search ?? "";
+      const match = !query || searchable.includes(query);
+      items.forEach((item) => {
+        item.hidden = !match;
       });
-      if (count) count.textContent = `${visible}件`;
-    };
-    search.addEventListener("input", filter);
-    filter();
+      visible += Number(match);
+    });
+
+    if (count) count.textContent = `${visible}件`;
+  };
+
+  const setView = (viewName) => {
+    if (!views.length) return;
+    const selected = views.some((view) => view.dataset.caseView === viewName)
+      ? viewName
+      : "table";
+
+    views.forEach((view) => {
+      view.hidden = view.dataset.caseView !== selected;
+    });
+    viewButtons.forEach((button) => {
+      button.setAttribute(
+        "aria-pressed",
+        String(button.dataset.viewButton === selected),
+      );
+    });
+
+    try {
+      window.localStorage.setItem("crewtrade-case-view", selected);
+    } catch {
+      // Storage can be disabled; the table remains the deterministic default.
+    }
+  };
+
+  if (search && caseGroups.size) {
+    search.addEventListener("input", filterCases);
   }
+
+  if (viewButtons.length && views.length) {
+    let initialView = "table";
+    try {
+      initialView = window.localStorage.getItem("crewtrade-case-view") || "table";
+    } catch {
+      initialView = "table";
+    }
+
+    viewButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        setView(button.dataset.viewButton || "table");
+      });
+    });
+    setView(initialView);
+  }
+
+  filterCases();
 
   const reportSelect = document.querySelector("[data-report-select]");
   if (reportSelect) {

--- a/web/static/table.css
+++ b/web/static/table.css
@@ -1,0 +1,216 @@
+[hidden] {
+  display: none !important;
+}
+
+.view-switch {
+  display: inline-flex;
+  padding: 3px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.view-button {
+  min-width: 3.2rem;
+  padding: 8px 12px;
+  border: 0;
+  border-radius: 999px;
+  color: var(--muted);
+  background: transparent;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.view-button[aria-pressed="true"] {
+  color: #fff;
+  background: var(--ink);
+  box-shadow: 0 6px 18px rgba(36, 54, 83, 0.18);
+}
+
+.case-table-shell,
+.report-table-shell {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+  box-shadow: var(--shadow);
+}
+
+.case-table,
+.report-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.case-table th,
+.case-table td,
+.report-table th,
+.report-table td {
+  padding: 15px 17px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.case-table th,
+.report-table th {
+  color: var(--muted);
+  background: rgba(143, 181, 236, 0.08);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.case-table tbody tr:last-child td,
+.report-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.case-table tbody tr,
+.report-table tbody tr {
+  transition: background 0.16s ease;
+}
+
+.case-table tbody tr:hover,
+.report-table tbody tr:hover {
+  background: rgba(143, 181, 236, 0.08);
+}
+
+.table-title {
+  --accent: var(--neutral);
+  display: grid;
+  grid-template-columns: 7px minmax(210px, 1fr);
+  gap: 12px;
+  align-items: stretch;
+  min-width: 260px;
+}
+
+.table-title[data-accent="blue"] { --accent: var(--blue); }
+.table-title[data-accent="lavender"] { --accent: var(--lavender); }
+.table-title[data-accent="rose"] { --accent: var(--rose); }
+.table-title[data-accent="mint"] { --accent: var(--mint); }
+.table-title[data-accent="apricot"] { --accent: var(--apricot); }
+
+.table-accent {
+  width: 7px;
+  min-height: 48px;
+  border-radius: 999px;
+  background: var(--accent);
+}
+
+.table-title strong,
+.table-title small {
+  display: block;
+}
+
+.table-title strong {
+  font-size: 0.98rem;
+  letter-spacing: -0.02em;
+}
+
+.table-title small {
+  max-width: 43rem;
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+.category-pill,
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 9px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.72);
+  font-size: 0.75rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.table-question {
+  min-width: 240px;
+  max-width: 420px;
+  color: #34445f;
+  line-height: 1.55;
+}
+
+.number-column {
+  text-align: right !important;
+  white-space: nowrap;
+}
+
+.table-date,
+.report-open {
+  color: #416da9;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.table-date:hover,
+.report-open:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.report-table {
+  font-size: 0.94rem;
+}
+
+.report-table td:first-child {
+  width: 34%;
+}
+
+.report-table td:nth-child(2) {
+  width: 20%;
+}
+
+.latest-row {
+  background: linear-gradient(90deg, rgba(143, 181, 236, 0.16), rgba(255, 255, 255, 0.2));
+}
+
+.latest-status {
+  color: var(--ink);
+  border-color: rgba(143, 181, 236, 0.45);
+  background: rgba(143, 181, 236, 0.22);
+}
+
+@media (max-width: 900px) {
+  .toolbar {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .case-table,
+  .report-table {
+    min-width: 820px;
+  }
+}
+
+@media (max-width: 620px) {
+  .toolbar {
+    justify-content: flex-start;
+  }
+
+  .view-switch {
+    order: 2;
+  }
+
+  .result-count {
+    order: 3;
+    margin-left: auto;
+  }
+
+  .case-table-shell,
+  .report-table-shell {
+    margin-right: -11px;
+    border-radius: var(--radius-small) 0 0 var(--radius-small);
+  }
+}

--- a/web/templates/static_index.html
+++ b/web/templates/static_index.html
@@ -6,6 +6,7 @@
   <meta name="description" content="CrewTradeの金融調査・時系列分析レポートを、テーマ、更新日、検証軸から閲覧できる公開ワークスペースです。">
   <title>CrewTrade | Financial Research Workspace</title>
   <link rel="stylesheet" href="assets/site.css">
+  <link rel="stylesheet" href="assets/table.css">
   <script defer src="assets/site.js"></script>
 </head>
 <body>

--- a/web/templates/static_index.html
+++ b/web/templates/static_index.html
@@ -48,13 +48,47 @@
         </div>
         <div class="toolbar">
           <input class="search" type="search" placeholder="テーマ・問いを検索" aria-label="調査テーマを検索" data-case-search>
-          <span class="result-count" data-result-count>{{ cases|length }}件</span>
+          <div class="view-switch" role="group" aria-label="一覧表示を切り替え">
+            <button class="view-button" type="button" data-view-button="table" aria-pressed="true">表</button>
+            <button class="view-button" type="button" data-view-button="cards" aria-pressed="false">カード</button>
+          </div>
+          <span class="result-count" data-result-count aria-live="polite">{{ cases|length }}件</span>
         </div>
       </div>
 
-      <div class="case-grid">
+      <div class="case-table-shell" data-case-view="table">
+        <table class="case-table">
+          <thead>
+            <tr>
+              <th scope="col">調査テーマ</th>
+              <th scope="col">分類</th>
+              <th scope="col">検証軸</th>
+              <th scope="col" class="number-column">レポート</th>
+              <th scope="col">最新更新</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for case in cases %}
+            <tr data-case-item data-case-row data-case-slug="{{ case.slug }}" data-search="{{ (case.title ~ ' ' ~ case.category ~ ' ' ~ case.summary ~ ' ' ~ case.question)|lower }}">
+              <td>
+                <a class="table-title" href="{{ case.slug }}/index.html" data-accent="{{ case.accent }}">
+                  <span class="table-accent" aria-hidden="true"></span>
+                  <span><strong>{{ case.title }}</strong><small>{{ case.summary }}</small></span>
+                </a>
+              </td>
+              <td><span class="category-pill">{{ case.category }}</span></td>
+              <td class="table-question">{{ case.question }}</td>
+              <td class="number-column"><strong>{{ case.report_count }}</strong></td>
+              <td><a class="table-date" href="{{ case.slug }}/{{ case.latest_date }}.html">{{ case.latest_date_label }} <span aria-hidden="true">→</span></a></td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+      <div class="case-grid" data-case-view="cards" hidden>
         {% for case in cases %}
-        <a class="case-card" href="{{ case.slug }}/index.html" data-case-card data-accent="{{ case.accent }}" data-search="{{ (case.title ~ ' ' ~ case.category ~ ' ' ~ case.summary ~ ' ' ~ case.question)|lower }}">
+        <a class="case-card" href="{{ case.slug }}/index.html" data-case-item data-case-card data-case-slug="{{ case.slug }}" data-accent="{{ case.accent }}" data-search="{{ (case.title ~ ' ' ~ case.category ~ ' ' ~ case.summary ~ ' ' ~ case.question)|lower }}">
           <div class="card-meta"><span>{{ case.category }}</span><span>{{ case.report_count }} reports</span></div>
           <h3>{{ case.title }}</h3>
           <p>{{ case.summary }}</p>

--- a/web/templates/static_use_case.html
+++ b/web/templates/static_use_case.html
@@ -6,6 +6,7 @@
   <meta name="description" content="{{ case.title }}の公開分析レポート一覧。">
   <title>{{ case.title }} | CrewTrade</title>
   <link rel="stylesheet" href="../assets/site.css">
+  <link rel="stylesheet" href="../assets/table.css">
   <script defer src="../assets/site.js"></script>
 </head>
 <body style="--case-accent: var(--{{ case.accent }});">

--- a/web/templates/static_use_case.html
+++ b/web/templates/static_use_case.html
@@ -6,6 +6,7 @@
   <meta name="description" content="{{ case.title }}の公開分析レポート一覧。">
   <title>{{ case.title }} | CrewTrade</title>
   <link rel="stylesheet" href="../assets/site.css">
+  <script defer src="../assets/site.js"></script>
 </head>
 <body style="--case-accent: var(--{{ case.accent }});">
   <header class="site-header shell">
@@ -27,11 +28,26 @@
     </section>
 
     <section class="section">
-      <div class="section-heading"><div><p class="eyebrow">Reports</p><h2>分析スナップショット</h2><p>作成日ごとの条件と結論の変化を追えます。</p></div></div>
-      <div class="report-list">
-        {% for date in dates %}
-        <a class="report-link{% if loop.first %} latest{% endif %}" href="{{ date }}.html"><strong>{{ date|report_date }}</strong><span>{% if loop.first %}最新レポート{% else %}過去スナップショット{% endif %}</span></a>
-        {% endfor %}
+      <div class="section-heading"><div><p class="eyebrow">Reports</p><h2>分析スナップショット</h2><p>作成日ごとの条件と結論の変化を、時系列の表で追えます。</p></div></div>
+      <div class="report-table-shell">
+        <table class="report-table">
+          <thead>
+            <tr>
+              <th scope="col">作成日</th>
+              <th scope="col">位置づけ</th>
+              <th scope="col">スナップショット</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for date in dates %}
+            <tr{% if loop.first %} class="latest-row"{% endif %}>
+              <td><strong>{{ date|report_date }}</strong></td>
+              <td>{% if loop.first %}<span class="status-pill latest-status">最新</span>{% else %}<span class="status-pill">履歴</span>{% endif %}</td>
+              <td><a class="report-open" href="{{ date }}.html">レポートを開く <span aria-hidden="true">→</span></a></td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       </div>
       <div class="notice"><strong>注意:</strong> 日付はレポートのスナップショット識別子です。本文でデータ取得日と対象期間を確認してください。</div>
     </section>


### PR DESCRIPTION
## 変更

- トップページをテーブル初期表示へ変更
- 表／カード切替と表示設定の保存を追加
- 検索結果を両表示で同期
- 各テーマのレポート履歴を時系列テーブルへ変更
- 最新レポートへの直接リンクを追加
- モバイル横スクロールとアクセシビリティを整備
- テーブル表示を静的サイト監査の必須要件へ追加

## 最終監査

GitHub Actions run #20で以下を確認しました。

- Python compile: PASS
- Static build: PASS
- 主要レポート: 16
- 補助レポート: 20
- ユースケース: 10
- HTML: 47
- manifest整合性: PASS
- 内部リンク: PASS
- トップの表／カード切替: PASS
- 全テーマページのレポートテーブル: PASS
- Pages artifact upload: PASS

## 統合

squash merge commit: `9f7d588084c5cff7d11cd97781e2f2fe56498c47`
