### PR TITLE
Rebuild the research catalogue around decisions and evidence

### DIFF
--- a/.github/workflows/uiux-static-site.yml
+++ b/.github/workflows/uiux-static-site.yml
@@ -41,7 +41,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --frozen
+        run: uv sync
 
       - name: Validate source syntax
         run: |

--- a/.github/workflows/uiux-static-site.yml
+++ b/.github/workflows/uiux-static-site.yml
@@ -1,0 +1,68 @@
+name: Build and audit research catalogue
+
+on:
+  pull_request:
+    paths:
+      - "web/**"
+      - "output/use_cases/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/uiux-static-site.yml"
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: research-catalogue-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Validate source syntax
+        run: |
+          uv run python -m compileall -q web
+          node --check web/static/site.js
+
+      - name: Build static site
+        run: uv run python web/build_static.py
+
+      - name: Audit generated site
+        run: uv run python web/audit_static.py
+
+      - name: Commit generated docs on main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs
+          if git diff --cached --quiet; then
+            echo "Generated docs are current."
+          else
+            git commit -m "Rebuild published research catalogue [skip ci]"
+            git push
+          fi

--- a/web/audit_static.py
+++ b/web/audit_static.py
@@ -9,6 +9,20 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DOCS_DIR = PROJECT_ROOT / "docs"
 CONTENT_REFRESH_DATE = "20260802"
 CONTENT_REFRESH_LABEL = "更新基準日: 2026-08-02"
+REQUIRED_CASE_FIELDS = {
+    "slug",
+    "title",
+    "category",
+    "purpose",
+    "scope",
+    "period",
+    "status",
+    "summary",
+    "question",
+    "warning",
+    "change_summary",
+    "accent",
+}
 
 
 class LocalReferenceParser(HTMLParser):
@@ -61,19 +75,31 @@ def audit() -> None:
         raise RuntimeError(f"Missing generated site files: {', '.join(missing)}")
 
     manifest = json.loads((DOCS_DIR / "site-manifest.json").read_text(encoding="utf-8"))
-    if manifest.get("schema_version") != 1:
-        raise RuntimeError("Unsupported or missing site manifest schema_version.")
+    if manifest.get("schema_version") != 2:
+        raise RuntimeError("Unsupported or missing site manifest schema_version 2.")
     if not manifest.get("cases") or not manifest.get("total_reports"):
         raise RuntimeError("Generated site manifest contains no reports.")
+    if manifest.get("site_latest_date") != CONTENT_REFRESH_DATE:
+        raise RuntimeError("site_latest_date does not match the audited content refresh date.")
+    if not manifest.get("purposes"):
+        raise RuntimeError("Generated site manifest contains no research purposes.")
 
     failures: list[str] = []
     index_text = (DOCS_DIR / "index.html").read_text(encoding="utf-8")
     required_index_markers = {
+        'class="skip-link"': "skip link",
+        'id="research-catalogue"': "catalogue landmark",
+        'data-case-controls': "catalogue controls",
+        'data-purpose-filter': "purpose filter",
+        'data-freshness-filter': "freshness filter",
+        'data-clear-filters': "clear filters action",
+        'data-empty-state': "empty state",
         'data-case-view="table"': "table view container",
         'data-case-view="cards"': "card view container",
         'data-view-button="table"': "table view button",
         'data-view-button="cards"': "card view button",
-        'class="case-table"': "research table",
+        'class="case-table"': "research comparison table",
+        'data-purpose-section': "purpose groups",
         'href="assets/table.css"': "table stylesheet",
     }
     for marker, label in required_index_markers.items():
@@ -83,6 +109,10 @@ def audit() -> None:
     manifest_report_count = 0
     manifest_companion_count = 0
     for case in manifest["cases"]:
+        missing_fields = sorted(REQUIRED_CASE_FIELDS.difference(case))
+        if missing_fields:
+            failures.append(f"manifest: {case.get('slug', '<unknown>')} missing {missing_fields}")
+
         slug = case.get("slug")
         dates = case.get("dates", [])
         companion_map = case.get("companions", {})
@@ -95,15 +125,22 @@ def audit() -> None:
                 f"manifest: {slug} latest report is {dates[0]}, expected {CONTENT_REFRESH_DATE}"
             )
 
+        if case.get("purpose") not in manifest["purposes"]:
+            failures.append(f"manifest: {slug} purpose is not registered")
+
         case_index = DOCS_DIR / slug / "index.html"
         if not case_index.is_file():
             failures.append(f"manifest: missing {slug}/index.html")
         else:
             case_text = case_index.read_text(encoding="utf-8")
-            if 'class="report-table"' not in case_text:
-                failures.append(f"{slug}/index.html: missing report table")
-            if 'href="../assets/table.css"' not in case_text:
-                failures.append(f"{slug}/index.html: missing table stylesheet")
+            for marker, label in {
+                'class="skip-link"': "skip link",
+                'id="report-history"': "report history target",
+                'class="report-table"': "report table",
+                'href="../assets/table.css"': "table stylesheet",
+            }.items():
+                if marker not in case_text:
+                    failures.append(f"{slug}/index.html: missing {label}")
 
         latest_report = DOCS_DIR / slug / f"{dates[0]}.html"
         if latest_report.is_file():
@@ -112,6 +149,8 @@ def audit() -> None:
                 failures.append(
                     f"{slug}/{dates[0]}.html: missing content refresh marker"
                 )
+            if 'id="report-content"' not in latest_text:
+                failures.append(f"{slug}/{dates[0]}.html: missing report content target")
 
         for date in dates:
             manifest_report_count += 1
@@ -133,12 +172,7 @@ def audit() -> None:
         )
 
     html_files = sorted(DOCS_DIR.rglob("*.html"))
-    expected_html_count = (
-        manifest_report_count
-        + manifest_companion_count
-        + len(manifest["cases"])
-        + 1
-    )
+    expected_html_count = manifest_report_count + manifest_companion_count + len(manifest["cases"]) + 1
     if len(html_files) != expected_html_count:
         failures.append(
             "generated HTML count does not match manifest "
@@ -150,9 +184,13 @@ def audit() -> None:
         relative = html_path.relative_to(DOCS_DIR)
         if '<html lang="ja">' not in text:
             failures.append(f"{relative}: html language is not ja")
+        if 'class="skip-link"' not in text:
+            failures.append(f"{relative}: missing skip link")
+        if "<main" not in text or "</main>" not in text:
+            failures.append(f"{relative}: missing main landmark")
         if "{{" in text or "{%" in text:
             failures.append(f"{relative}: unresolved Jinja template marker")
-        if "#0d1117" in text or "Select a use case" in text:
+        if "#0d1117" in text or "Select a use case" in text or "View analysis reports" in text:
             failures.append(f"{relative}: legacy dashboard content remains")
 
         parser = LocalReferenceParser()
@@ -177,7 +215,7 @@ def audit() -> None:
         f"{manifest['total_reports']} reports / "
         f"{manifest_companion_count} companion pages / "
         f"{len(manifest['cases'])} cases / {len(html_files)} HTML files / "
-        f"table views enabled / content refreshed {CONTENT_REFRESH_DATE}"
+        f"decision catalogue enabled / content refreshed {CONTENT_REFRESH_DATE}"
     )
 
 

--- a/web/build_static.py
+++ b/web/build_static.py
@@ -167,7 +167,7 @@ def rewrite_asset_links(markdown_text: str, rewrites: dict[str, str]) -> str:
         updated = updated.replace(f"]({source})", f"]({target})")
         updated = updated.replace(f'src="{source}"', f'src="{target}"')
         updated = updated.replace(f"src='{source}'", f"src='{target}'")
-        updated = updated.replace(f'href="{source}"', f'href="{target}'")
+        updated = updated.replace(f'href="{source}"', f'href="{target}"')
         updated = updated.replace(f"href='{source}'", f"href='{target}'")
     return updated
 
@@ -269,7 +269,7 @@ def build() -> None:
     for card in cards:
         card["freshness"] = "current" if card["latest_date"] == site_latest_date else "archive"
 
-    purposes = []
+    purposes: list[str] = []
     for card in cards:
         purpose = str(card["purpose"])
         if purpose not in purposes:

--- a/web/build_static.py
+++ b/web/build_static.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import markdown
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 
-from catalog import describe_case, format_report_date
+from catalog import describe_case, format_report_date, purpose_rank
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 OUTPUT_DIR = PROJECT_ROOT / "output" / "use_cases"
@@ -167,7 +167,7 @@ def rewrite_asset_links(markdown_text: str, rewrites: dict[str, str]) -> str:
         updated = updated.replace(f"]({source})", f"]({target})")
         updated = updated.replace(f'src="{source}"', f'src="{target}"')
         updated = updated.replace(f"src='{source}'", f"src='{target}'")
-        updated = updated.replace(f'href="{source}"', f'href="{target}"')
+        updated = updated.replace(f'href="{source}"', f'href="{target}'")
         updated = updated.replace(f"href='{source}'", f"href='{target}'")
     return updated
 
@@ -264,9 +264,23 @@ def build() -> None:
     if not cards:
         raise RuntimeError("No publishable Markdown reports were found under output/use_cases.")
 
+    cards.sort(key=lambda item: (purpose_rank(str(item["purpose"])), str(item["title"])))
+    site_latest_date = max(str(card["latest_date"]) for card in cards)
+    for card in cards:
+        card["freshness"] = "current" if card["latest_date"] == site_latest_date else "archive"
+
+    purposes = []
+    for card in cards:
+        purpose = str(card["purpose"])
+        if purpose not in purposes:
+            purposes.append(purpose)
+
     index_html = env.get_template("static_index.html").render(
         cases=cards,
+        purposes=purposes,
         total_reports=sum(int(card["report_count"]) for card in cards),
+        site_latest_date=site_latest_date,
+        site_latest_date_label=format_report_date(site_latest_date),
     )
     (DOCS_DIR / "index.html").write_text(index_html, encoding="utf-8")
 
@@ -311,8 +325,10 @@ def build() -> None:
                 (case_docs_dir / output_name).write_text(companion_html, encoding="utf-8")
 
     manifest = {
-        "schema_version": 1,
+        "schema_version": 2,
         "source_revision": os.environ.get("GITHUB_SHA", "local"),
+        "site_latest_date": site_latest_date,
+        "purposes": purposes,
         "cases": report_index,
         "total_reports": sum(len(item["dates"]) for item in report_index),
     }

--- a/web/catalog.py
+++ b/web/catalog.py
@@ -1,7 +1,7 @@
 """Presentation metadata for CrewTrade research use cases.
 
-The analytical outputs remain the source of truth. This module only provides
-stable labels and explanations for the dashboard.
+Analytical outputs remain the source of truth. This module provides stable,
+human-readable navigation metadata. It must not invent numerical results.
 """
 
 from __future__ import annotations
@@ -12,74 +12,144 @@ CASE_CATALOG: Final[dict[str, dict[str, str]]] = {
     "credit": {
         "title": "クレジット・スプレッド",
         "category": "信用環境",
+        "purpose": "リスク管理",
+        "scope": "投資適格・BBB・ハイイールドの信用市場",
+        "period": "直近観測と過去のストレス局面",
+        "status": "要監視",
         "summary": "投資適格・BBB・ハイイールドのOASを分け、信用不安と割高なリスクテイクを監視します。",
         "question": "信用リスクへの追加補償は、悪化余地に見合っているか",
+        "warning": "スプレッドの縮小だけで安全性を断定しません。格付け、デフォルト、流動性を併記します。",
+        "change_summary": "最新スナップショットのデータ時点と監視条件を更新。",
         "accent": "apricot",
     },
     "imura": {
         "title": "ファンド・指数比較",
         "category": "運用評価",
+        "purpose": "運用評価",
+        "scope": "ファンドと基準指数",
+        "period": "同一期間・配当・費用条件",
+        "status": "比較可能",
         "summary": "ファンドと基準指数を同一期間・同一条件で比較し、コスト控除後の超過収益と下振れを検証します。",
         "question": "超過収益は、比較条件とリスクをそろえても残るか",
+        "warning": "比較期間、配当、費用、通貨条件が一致しない結果は横並びにしません。",
+        "change_summary": "比較条件とリスク指標を最新レポートへ統合。",
         "accent": "blue",
     },
     "index_7_portfolio": {
         "title": "7指数ポートフォリオ",
         "category": "資産配分",
+        "purpose": "資産配分",
+        "scope": "株式・債券・実物資産を含む7指数",
+        "period": "下落局面を含む検証期間",
+        "status": "比較可能",
         "summary": "複数指数の組み合わせを、収益率だけでなく共通ファクター、分散効果、最大下落率から評価します。",
         "question": "分散は、実際の下落局面でも機能するか",
+        "warning": "銘柄数ではなく、相関と共通リスク因子で実効分散を確認します。",
+        "change_summary": "共通ファクターと下落局面の検証を最新化。",
         "accent": "lavender",
     },
     "index_etf_comparison": {
         "title": "指数ETF比較",
         "category": "商品比較",
+        "purpose": "運用評価",
+        "scope": "同一または近接指数へ連動するETF",
+        "period": "同一通貨・配当・費用条件",
+        "status": "比較可能",
         "summary": "連動対象、通貨、配当、費用、流動性、トラッキング差をそろえ、ETFを比較可能な形に整理します。",
         "question": "同じ指数名でも、投資結果を分ける条件は何か",
+        "warning": "名称が同じでも連動指数、為替、分配、税、流動性が異なります。",
+        "change_summary": "費用とトラッキング差を含む比較軸へ更新。",
         "accent": "mint",
     },
     "legendary_investors": {
         "title": "著名投資家リサーチ",
         "category": "公開情報調査",
+        "purpose": "公開情報調査",
+        "scope": "SEC提出資料・年次報告書・株主書簡",
+        "period": "公開済みの最新標準四半期",
+        "status": "開示遅延あり",
         "summary": "SEC提出資料と一次情報を起点に、開示遅延、再現可能性、資本配分の制約を切り分けます。",
         "question": "物語ではなく、検証可能な判断原則は何か",
+        "warning": "13Fは四半期末の限定情報であり、現在保有、現金、空売りの全体像ではありません。",
+        "change_summary": "利用可能な開示四半期と提出期限を更新。",
         "accent": "rose",
     },
     "oracle": {
         "title": "Oracle実績・予測監査",
         "category": "企業分析・予測",
+        "purpose": "産業・企業分析",
+        "scope": "Oracleのクラウド実績・受注残・設備投資",
+        "period": "開示実績と未検証予測を分離",
+        "status": "要検証",
         "summary": "Oracleのクラウド実績とRPOを確認し、実測値と未検証の時系列予測を分離します。",
         "question": "クラウド成長と受注残は、設備投資回収を伴う売上・キャッシュフローへ転換するか",
+        "warning": "モデル予測を会社実績または会社予想として表示しません。",
+        "change_summary": "実績・会社開示・モデル予測の境界を再整理。",
         "accent": "apricot",
     },
     "precious_metals_spread": {
         "title": "貴金属スプレッド",
         "category": "相対価値",
+        "purpose": "マクロ・市場構造",
+        "scope": "金・銀・白金族の価格比とスプレッド",
+        "period": "同一時点・同一通貨の時系列",
+        "status": "要監視",
         "summary": "金・銀・白金族の価格差と比率を同一条件で追い、平均回帰と構造変化を分けます。",
         "question": "価格差は平均回帰か、構造変化か",
+        "warning": "単位、取引時間、通貨、先物ロールが異なる系列を直接比較しません。",
+        "change_summary": "系列条件と構造変化の監査観点を更新。",
         "accent": "lavender",
     },
     "securities_collateral_loan": {
         "title": "証券担保ローン",
         "category": "リスク管理",
+        "purpose": "リスク管理",
+        "scope": "担保評価・金利・追証・強制売却条件",
+        "period": "契約条件と下落シナリオ",
+        "status": "契約依存",
         "summary": "実契約の金利、担保下落、警戒線、強制売却条件を明示し、意思決定余力を検証します。",
         "question": "どの下落率から意思決定の自由が失われるか",
+        "warning": "契約条項と担保掛目を確認せず、一般的な安全水準を適用しません。",
+        "change_summary": "警戒線と強制売却条件の表示を更新。",
         "accent": "rose",
     },
     "semiconductors": {
         "title": "半導体サイクル",
         "category": "産業分析",
+        "purpose": "産業・企業分析",
+        "scope": "半導体企業・需要・価格・能力・設備投資",
+        "period": "四半期実績と中期能力計画",
+        "status": "継続更新",
         "summary": "市場成長を数量、価格、製品ミックス、能力、設備投資へ分解し、AI集中と循環要因を区別します。",
         "question": "利益成長は数量・価格・能力のどこから生じたか",
+        "warning": "会社実績、会社予想、業界推計、独自シナリオを混在させません。",
+        "change_summary": "数量・価格・能力の分解と一次資料を更新。",
         "accent": "blue",
     },
     "yield_spread": {
         "title": "金利・イールドスプレッド",
         "category": "マクロ",
+        "purpose": "マクロ・市場構造",
+        "scope": "政策金利・国債カーブ・実質金利・通貨",
+        "period": "現在のカーブと過去推移",
+        "status": "継続更新",
         "summary": "政策金利と国債カーブを分け、成長、インフレ、財政、期間プレミアムの変化を読み解きます。",
         "question": "金利差の変化は、どの期待とリスクプレミアムを反映しているか",
+        "warning": "名目金利差だけで為替方向を断定せず、実質金利、ヘッジ費用、ポジションを確認します。",
+        "change_summary": "金利差の構成要因と比較条件を更新。",
         "accent": "mint",
     },
 }
+
+PURPOSE_ORDER: Final[tuple[str, ...]] = (
+    "運用評価",
+    "資産配分",
+    "リスク管理",
+    "産業・企業分析",
+    "マクロ・市場構造",
+    "公開情報調査",
+    "未分類",
+)
 
 
 def describe_case(slug: str) -> dict[str, str]:
@@ -92,10 +162,24 @@ def describe_case(slug: str) -> dict[str, str]:
         "slug": slug,
         "title": title,
         "category": "未分類",
+        "purpose": "未分類",
+        "scope": "対象未登録",
+        "period": "レポート本文で確認",
+        "status": "説明未登録",
         "summary": "分析出力は存在しますが、ダッシュボード用の説明はまだ登録されていません。",
         "question": "対象、期間、計算条件をレポート本文で確認してください",
+        "warning": "表示メタデータが未登録です。本文を一次情報として確認してください。",
+        "change_summary": "差分要約は未登録です。",
         "accent": "neutral",
     }
+
+
+def purpose_rank(value: str) -> int:
+    """Return a deterministic display rank for research purposes."""
+    try:
+        return PURPOSE_ORDER.index(value)
+    except ValueError:
+        return len(PURPOSE_ORDER)
 
 
 def format_report_date(value: str) -> str:

--- a/web/static/site.css
+++ b/web/static/site.css
@@ -1,9 +1,10 @@
 :root {
   --canvas: #fbfaf7;
-  --paper: rgba(255, 255, 255, 0.88);
+  --paper: rgba(255, 255, 255, 0.94);
   --ink: #243653;
-  --muted: #66738b;
-  --line: rgba(70, 91, 126, 0.14);
+  --muted: #5f6d83;
+  --line: rgba(55, 76, 112, 0.22);
+  --focus: #245fa8;
   --blue: #8fb5ec;
   --lavender: #b9a8e6;
   --rose: #efb4c1;
@@ -12,180 +13,273 @@
   --neutral: #cbd3df;
   --radius: 22px;
   --radius-small: 14px;
-  --shadow: 0 18px 50px rgba(76, 91, 125, 0.09);
-  --content: 1180px;
+  --shadow: 0 18px 48px rgba(76, 91, 125, 0.1);
+  --content: 1240px;
 }
 
 * { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
+html { scroll-behavior: smooth; scroll-padding-top: 24px; }
 body {
   margin: 0;
   min-height: 100vh;
   color: var(--ink);
   background:
-    radial-gradient(circle at 12% 8%, rgba(143, 181, 236, 0.24), transparent 28rem),
-    radial-gradient(circle at 88% 3%, rgba(239, 180, 193, 0.2), transparent 24rem),
+    radial-gradient(circle at 12% 8%, rgba(143, 181, 236, 0.22), transparent 28rem),
+    radial-gradient(circle at 88% 3%, rgba(239, 180, 193, 0.18), transparent 24rem),
     var(--canvas);
   font-family: Inter, "Noto Sans JP", "Hiragino Sans", "Yu Gothic UI", system-ui, -apple-system, sans-serif;
-  line-height: 1.75;
+  font-size: 16px;
+  line-height: 1.7;
 }
 
 a { color: inherit; text-decoration: none; }
-a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible {
-  outline: 3px solid rgba(143, 181, 236, 0.58);
+a:hover { text-decoration: underline; text-underline-offset: 0.2em; }
+a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible, [tabindex="0"]:focus-visible {
+  outline: 3px solid var(--focus);
   outline-offset: 3px;
 }
+button, input, select { font: inherit; }
+button, select, input[type="search"] { min-height: 44px; }
 img { max-width: 100%; height: auto; }
+[hidden] { display: none !important; }
 
-.shell { width: min(calc(100% - 32px), var(--content)); margin: 0 auto; }
-.site-header { padding: 24px 0 0; }
+.skip-link {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 100;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: var(--ink);
+  color: #fff;
+  transform: translateY(-160%);
+}
+.skip-link:focus { transform: translateY(0); }
+
+.shell { width: min(calc(100% - 32px), var(--content)); margin-inline: auto; }
+.site-header { padding-top: 20px; }
 .header-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 20px;
-  padding: 14px 18px;
+  padding: 12px 18px;
   border: 1px solid var(--line);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.72);
-  box-shadow: 0 10px 30px rgba(76, 91, 125, 0.06);
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 10px 30px rgba(76, 91, 125, 0.07);
   backdrop-filter: blur(16px);
 }
-.brand { display: flex; align-items: center; gap: 11px; font-weight: 800; letter-spacing: -0.02em; }
+.brand { display: inline-flex; min-height: 44px; align-items: center; gap: 11px; font-weight: 850; }
 .brand-mark {
-  display: grid; place-items: center; width: 34px; height: 34px; border-radius: 12px;
-  background: linear-gradient(145deg, var(--blue), var(--lavender));
-  color: #fff; font-size: 0.8rem; box-shadow: inset 0 0 0 1px rgba(255,255,255,.45);
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 12px;
+  background: linear-gradient(145deg, #598acb, #846dbb);
+  color: #fff;
+  font-size: 0.875rem;
 }
-.header-links { display: flex; gap: 8px; color: var(--muted); font-size: 0.88rem; }
-.header-links a { padding: 7px 11px; border-radius: 999px; }
-.header-links a:hover { background: rgba(143, 181, 236, 0.14); color: var(--ink); }
+.header-links { display: flex; flex-wrap: wrap; gap: 4px; }
+.header-links a { display: inline-flex; min-height: 44px; align-items: center; padding: 8px 12px; border-radius: 999px; color: var(--muted); }
+.header-links a:hover { background: rgba(143, 181, 236, 0.18); color: var(--ink); text-decoration: none; }
 
-main { padding: 54px 0 80px; }
-.hero { display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(280px, .55fr); gap: 36px; align-items: end; }
-.eyebrow { margin: 0 0 12px; color: #5577a7; font-size: .78rem; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
-h1 { margin: 0; max-width: 15ch; font-size: clamp(2.7rem, 8vw, 5.8rem); line-height: .98; letter-spacing: -.065em; }
-.hero-copy { margin: 24px 0 0; max-width: 680px; color: var(--muted); font-size: clamp(1rem, 2vw, 1.15rem); }
+main { padding: 56px 0 80px; }
+.hero { display: grid; grid-template-columns: minmax(0, 1.5fr) minmax(280px, 0.5fr); gap: 36px; align-items: end; }
+.eyebrow { margin: 0 0 12px; color: #496b99; font-size: 0.875rem; font-weight: 850; letter-spacing: 0.1em; text-transform: uppercase; }
+h1 { margin: 0; max-width: 17ch; font-size: clamp(2.65rem, 7vw, 5.6rem); line-height: 1; letter-spacing: -0.06em; }
+.hero-copy { max-width: 760px; margin: 24px 0 0; color: var(--muted); font-size: clamp(1rem, 2vw, 1.15rem); }
 .hero-note, .notice {
-  border: 1px solid var(--line); border-radius: var(--radius); background: var(--paper); box-shadow: var(--shadow);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+  box-shadow: var(--shadow);
 }
 .hero-note { padding: 24px; }
-.hero-note strong { display: block; margin-bottom: 8px; font-size: 1rem; }
-.hero-note p { margin: 0; color: var(--muted); font-size: .92rem; }
-
+.hero-note strong { display: block; margin: 8px 0; font-size: 1.1rem; }
+.hero-note p { margin: 0; color: var(--muted); }
+.status-label { display: inline-flex; padding: 5px 9px; border: 1px solid var(--line); border-radius: 999px; font-size: 0.875rem; font-weight: 800; }
 .metrics { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 28px; }
-.metric { padding: 8px 13px; border: 1px solid var(--line); border-radius: 999px; background: rgba(255,255,255,.62); font-size: .86rem; }
+.metric { padding: 8px 13px; border: 1px solid var(--line); border-radius: 999px; background: rgba(255, 255, 255, 0.75); font-size: 0.9rem; }
 .metric strong { margin-right: 4px; }
 
 .section { margin-top: 64px; }
-.section-heading { display: flex; justify-content: space-between; align-items: end; gap: 20px; margin-bottom: 22px; }
-.section-heading h2 { margin: 0; font-size: clamp(1.55rem, 3vw, 2.35rem); letter-spacing: -.04em; }
-.section-heading p { margin: 5px 0 0; color: var(--muted); }
+.section-heading { display: flex; justify-content: space-between; align-items: end; gap: 20px; margin-bottom: 20px; }
+.section-heading h2 { margin: 0; font-size: clamp(1.7rem, 3vw, 2.5rem); letter-spacing: -0.04em; }
+.section-heading p { margin: 6px 0 0; color: var(--muted); }
 
-.toolbar { display: flex; align-items: center; gap: 12px; }
-.search {
-  width: min(340px, 70vw); padding: 12px 16px; color: var(--ink); background: rgba(255,255,255,.82);
-  border: 1px solid var(--line); border-radius: 999px; font: inherit;
+.catalogue-controls {
+  display: grid;
+  grid-template-columns: minmax(260px, 2fr) repeat(3, minmax(170px, 1fr)) auto;
+  gap: 12px;
+  align-items: end;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: var(--shadow);
 }
-.result-count { min-width: 4.5rem; color: var(--muted); font-size: .86rem; text-align: right; }
+.control-field { display: grid; gap: 6px; min-width: 0; }
+.control-field > span { color: var(--muted); font-size: 0.875rem; font-weight: 800; }
+.search, .control-field select {
+  width: 100%;
+  min-width: 0;
+  padding: 10px 13px;
+  border: 1px solid rgba(55, 76, 112, 0.32);
+  border-radius: 13px;
+  background: #fff;
+  color: var(--ink);
+}
+.view-switch { display: grid; grid-template-columns: 1fr 1fr; gap: 5px; padding: 4px; border: 1px solid var(--line); border-radius: 13px; background: #fff; }
+.view-button, .clear-button, .empty-state button {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #fff;
+  color: var(--ink);
+  cursor: pointer;
+  font-weight: 750;
+}
+.view-button[aria-pressed="true"] { background: var(--ink); color: #fff; }
+.clear-button { padding-inline: 15px; }
+.active-summary { display: flex; flex-wrap: wrap; gap: 8px 14px; align-items: center; min-height: 44px; padding: 10px 4px; color: var(--muted); }
+.active-summary strong { color: var(--ink); }
+.empty-state { padding: 42px 20px; border: 1px dashed rgba(55, 76, 112, 0.4); border-radius: var(--radius); background: rgba(255, 255, 255, 0.72); text-align: center; }
+.empty-state h3 { margin: 0 0 5px; }
+.empty-state p { margin: 0 0 16px; color: var(--muted); }
+.empty-state button { padding: 8px 15px; }
 
-.case-grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 16px; }
+.case-table-shell, .report-table-shell { overflow-x: auto; border: 1px solid var(--line); border-radius: var(--radius); background: #fff; box-shadow: var(--shadow); }
+.case-table { width: 100%; min-width: 1100px; border-collapse: collapse; }
+.case-table caption { padding: 14px 16px; color: var(--muted); text-align: left; font-size: 0.875rem; }
+.case-table th, .case-table td { padding: 15px; border-top: 1px solid var(--line); text-align: left; vertical-align: top; }
+.case-table thead th { position: sticky; top: 0; z-index: 1; background: #f2f5f9; color: #42516a; font-size: 0.875rem; }
+.case-table tbody tr:hover { background: rgba(143, 181, 236, 0.08); }
+.table-title { --accent: var(--neutral); display: flex; min-width: 250px; gap: 11px; }
+.table-title[data-accent="blue"] { --accent: var(--blue); }
+.table-title[data-accent="lavender"] { --accent: var(--lavender); }
+.table-title[data-accent="rose"] { --accent: var(--rose); }
+.table-title[data-accent="mint"] { --accent: var(--mint); }
+.table-title[data-accent="apricot"] { --accent: var(--apricot); }
+.table-accent { flex: 0 0 auto; width: 7px; min-height: 54px; border-radius: 999px; background: var(--accent); }
+.table-title strong, .table-title small, .cell-secondary, .cell-warning { display: block; }
+.table-title small, .cell-secondary { margin-top: 4px; color: var(--muted); font-size: 0.875rem; }
+.cell-warning { max-width: 290px; margin-top: 6px; color: #6c3f44; font-size: 0.875rem; }
+.category-pill, .status-pill { display: inline-flex; align-items: center; min-height: 28px; padding: 3px 9px; border: 1px solid var(--line); border-radius: 999px; background: #f6f8fb; font-size: 0.875rem; font-weight: 750; }
+.status-pill::before { content: "•"; margin-right: 5px; }
+.table-date { font-weight: 800; color: #285f9f; }
+.number-column { text-align: right !important; }
+
+.purpose-groups { display: grid; gap: 34px; }
+.purpose-section { min-width: 0; }
+.purpose-heading { display: flex; justify-content: space-between; align-items: center; gap: 16px; margin-bottom: 12px; }
+.purpose-heading h3 { margin: 0; font-size: 1.45rem; }
+.purpose-heading span { color: var(--muted); }
+.case-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
 .case-card {
   --accent: var(--neutral);
-  grid-column: span 4; display: flex; flex-direction: column; min-height: 300px; padding: 24px;
-  border: 1px solid var(--line); border-radius: var(--radius); background: var(--paper); box-shadow: var(--shadow);
-  transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-top: 7px solid var(--accent);
+  border-radius: var(--radius);
+  background: var(--paper);
+  box-shadow: var(--shadow);
 }
-.case-card:hover { transform: translateY(-4px); border-color: color-mix(in srgb, var(--accent) 70%, var(--line)); box-shadow: 0 24px 58px rgba(76, 91, 125, .13); }
 .case-card[data-accent="blue"] { --accent: var(--blue); }
 .case-card[data-accent="lavender"] { --accent: var(--lavender); }
 .case-card[data-accent="rose"] { --accent: var(--rose); }
 .case-card[data-accent="mint"] { --accent: var(--mint); }
 .case-card[data-accent="apricot"] { --accent: var(--apricot); }
-.case-card::before { content: ""; width: 52px; height: 7px; margin-bottom: 24px; border-radius: 999px; background: var(--accent); }
-.card-meta { display: flex; justify-content: space-between; gap: 12px; color: var(--muted); font-size: .78rem; }
-.case-card h3 { margin: 17px 0 8px; font-size: 1.35rem; letter-spacing: -.035em; }
-.case-card p { margin: 0; color: var(--muted); font-size: .92rem; }
-.card-question { margin-top: auto !important; padding-top: 22px; color: var(--ink) !important; font-weight: 700; }
-.card-question::before { content: "検証軸"; display: block; margin-bottom: 4px; color: var(--muted); font-size: .7rem; font-weight: 700; letter-spacing: .1em; }
-.card-arrow { display: inline-block; margin-top: 18px; font-weight: 800; }
-.case-card[hidden] { display: none; }
+.card-meta, .card-footer { display: flex; justify-content: space-between; gap: 12px; align-items: center; color: var(--muted); font-size: 0.875rem; }
+.case-card h4 { margin: 14px 0 9px; font-size: 1.45rem; letter-spacing: -0.03em; }
+.case-card h4 a { display: inline-flex; min-height: 44px; align-items: center; }
+.card-question { margin: 0; font-weight: 750; }
+.card-question span { display: block; margin-bottom: 3px; color: var(--muted); font-size: 0.875rem; font-weight: 750; }
+.card-facts { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin: 16px 0; }
+.card-facts div { padding: 11px; border-radius: 12px; background: #f4f6f9; }
+.card-facts dt { color: var(--muted); font-size: 0.875rem; font-weight: 750; }
+.card-facts dd { margin: 3px 0 0; }
+.card-warning { margin: 0 0 16px; padding: 12px; border-left: 4px solid #9e5961; background: #fff3f4; color: #643b40; }
+.card-warning strong { display: block; }
+.card-footer { margin-top: auto; padding-top: 13px; border-top: 1px solid var(--line); }
+.card-footer a { display: inline-flex; min-height: 44px; align-items: center; font-weight: 800; color: #285f9f; }
 
 .process-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
-.process-step { padding: 22px; border: 1px solid var(--line); border-radius: var(--radius); background: rgba(255,255,255,.58); }
-.process-step span { display: inline-grid; place-items: center; width: 30px; height: 30px; border-radius: 10px; background: var(--ink); color: #fff; font-size: .78rem; font-weight: 800; }
-.process-step h3 { margin: 14px 0 5px; font-size: 1rem; }
-.process-step p { margin: 0; color: var(--muted); font-size: .88rem; }
-.notice { margin-top: 16px; padding: 22px 24px; color: var(--muted); }
+.process-step { padding: 22px; border: 1px solid var(--line); border-radius: var(--radius); background: rgba(255, 255, 255, 0.72); }
+.process-step > span { display: inline-grid; place-items: center; width: 32px; height: 32px; border-radius: 10px; background: var(--ink); color: #fff; font-size: 0.875rem; font-weight: 800; }
+.process-step h3 { margin: 14px 0 5px; }
+.process-step p { margin: 0; color: var(--muted); }
+.notice { margin-top: 16px; padding: 20px 22px; color: var(--muted); }
 .notice strong { color: var(--ink); }
 
-.breadcrumbs { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 28px; color: var(--muted); font-size: .86rem; }
-.breadcrumbs a:hover { color: var(--ink); }
-.case-hero { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 28px; align-items: end; }
-.case-hero h1 { max-width: 18ch; font-size: clamp(2.4rem, 6vw, 4.8rem); }
-.case-summary { max-width: 700px; margin: 18px 0 0; color: var(--muted); }
-.question-box { max-width: 360px; padding: 20px; border-radius: var(--radius); background: color-mix(in srgb, var(--case-accent, var(--blue)) 22%, white); }
+.breadcrumbs { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 28px; color: var(--muted); }
+.breadcrumbs a { min-height: 44px; display: inline-flex; align-items: center; }
+.case-hero { display: grid; grid-template-columns: minmax(0, 1fr) minmax(280px, 0.45fr); gap: 28px; align-items: end; }
+.case-hero h1 { max-width: 20ch; font-size: clamp(2.4rem, 6vw, 4.8rem); }
+.case-summary { max-width: 760px; margin: 18px 0 0; color: var(--muted); }
+.question-box { padding: 20px; border: 1px solid var(--line); border-radius: var(--radius); background: color-mix(in srgb, var(--case-accent, var(--blue)) 22%, white); }
 .question-box small { display: block; margin-bottom: 5px; color: var(--muted); font-weight: 700; }
-
 .report-list { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
 .report-link { padding: 20px; border: 1px solid var(--line); border-radius: var(--radius); background: var(--paper); box-shadow: var(--shadow); }
-.report-link:hover { border-color: var(--blue); transform: translateY(-2px); }
-.report-link strong { display: block; }
-.report-link span { color: var(--muted); font-size: .82rem; }
-.report-link.latest { background: linear-gradient(145deg, rgba(143,181,236,.25), rgba(255,255,255,.85)); }
-
-.report-layout { display: grid; grid-template-columns: 260px minmax(0, 1fr); gap: 28px; align-items: start; }
-.report-sidebar { position: sticky; top: 24px; padding: 18px; border: 1px solid var(--line); border-radius: var(--radius); background: rgba(255,255,255,.72); }
-.report-sidebar label { display: block; margin-bottom: 8px; color: var(--muted); font-size: .76rem; font-weight: 800; letter-spacing: .08em; }
-.report-sidebar select { width: 100%; padding: 11px 12px; color: var(--ink); background: #fff; border: 1px solid var(--line); border-radius: 12px; font: inherit; }
-.report-sidebar dl { margin: 22px 0 0; }
-.report-sidebar dt { color: var(--muted); font-size: .75rem; }
-.report-sidebar dd { margin: 2px 0 14px; font-size: .9rem; font-weight: 700; overflow-wrap: anywhere; }
-.report-panel { min-width: 0; }
+.report-layout { display: grid; grid-template-columns: 280px minmax(0, 1fr); gap: 28px; align-items: start; }
+.report-sidebar { position: sticky; top: 24px; padding: 18px; border: 1px solid var(--line); border-radius: var(--radius); background: rgba(255, 255, 255, 0.84); }
+.report-sidebar label { display: block; margin-bottom: 8px; color: var(--muted); font-size: 0.875rem; font-weight: 800; }
+.report-sidebar select { width: 100%; padding: 10px 12px; border: 1px solid var(--line); border-radius: 12px; background: #fff; color: var(--ink); }
+.report-sidebar dl { margin: 20px 0 0; }
+.report-sidebar dt { color: var(--muted); font-size: 0.875rem; }
+.report-sidebar dd { margin: 2px 0 13px; font-weight: 700; overflow-wrap: anywhere; }
 .report-heading { margin-bottom: 18px; padding: 24px 28px; border: 1px solid var(--line); border-radius: var(--radius); background: var(--paper); box-shadow: var(--shadow); }
 .report-heading h1 { max-width: none; font-size: clamp(2rem, 4vw, 3.4rem); }
-.report-heading p { margin: 10px 0 0; color: var(--muted); }
-.report-body { padding: clamp(22px, 5vw, 54px); border: 1px solid var(--line); border-radius: var(--radius); background: #fff; box-shadow: var(--shadow); overflow: hidden; }
-.report-body h1, .report-body h2, .report-body h3, .report-body h4 { line-height: 1.35; letter-spacing: -.025em; }
+.report-heading p { color: var(--muted); }
+.report-body { min-width: 0; padding: clamp(22px, 5vw, 52px); border: 1px solid var(--line); border-radius: var(--radius); background: #fff; box-shadow: var(--shadow); overflow: hidden; }
+.report-body h1, .report-body h2, .report-body h3, .report-body h4 { line-height: 1.35; letter-spacing: -0.025em; }
 .report-body h1 { max-width: none; font-size: 2rem; }
-.report-body h2 { margin-top: 2.4em; padding-bottom: .45em; border-bottom: 1px solid var(--line); font-size: 1.5rem; }
-.report-body h3 { margin-top: 2em; }
+.report-body h2 { margin-top: 2.4em; padding-bottom: 0.45em; border-bottom: 1px solid var(--line); font-size: 1.5rem; }
 .report-body p, .report-body li { color: #34445f; }
-.report-body a { color: #416da9; text-decoration: underline; text-underline-offset: 3px; }
+.report-body a { color: #285f9f; text-decoration: underline; text-underline-offset: 3px; }
 .report-body table { display: block; width: 100%; margin: 22px 0; border-collapse: collapse; overflow-x: auto; }
 .report-body th, .report-body td { padding: 11px 13px; border: 1px solid var(--line); text-align: left; white-space: nowrap; }
-.report-body th { background: rgba(143,181,236,.13); }
+.report-body th { background: rgba(143, 181, 236, 0.16); }
 .report-body pre { padding: 18px; border-radius: var(--radius-small); background: #f4f6fa; overflow-x: auto; }
-.report-body code { padding: .15em .35em; border-radius: 6px; background: #f1f3f7; }
-.report-body blockquote { margin: 22px 0; padding: 14px 20px; border-left: 5px solid var(--lavender); background: rgba(185,168,230,.12); }
-.report-body figure, .report-body img { border-radius: var(--radius-small); }
-
-.site-footer { padding: 0 0 46px; color: var(--muted); font-size: .82rem; }
+.report-body code { padding: 0.15em 0.35em; border-radius: 6px; background: #f1f3f7; }
+.report-body blockquote { margin: 22px 0; padding: 14px 20px; border-left: 5px solid var(--lavender); background: rgba(185, 168, 230, 0.12); }
+.site-footer { padding-bottom: 46px; color: var(--muted); }
 .footer-inner { display: flex; justify-content: space-between; gap: 18px; padding-top: 20px; border-top: 1px solid var(--line); }
 
+@media (max-width: 1050px) {
+  .catalogue-controls { grid-template-columns: 1fr 1fr 1fr; }
+  .control-search { grid-column: 1 / -1; }
+  .clear-button { width: 100%; }
+}
 @media (max-width: 900px) {
   .hero, .case-hero, .report-layout { grid-template-columns: 1fr; }
-  .case-card { grid-column: span 6; }
+  .case-grid { grid-template-columns: 1fr; }
   .report-sidebar { position: static; }
   .report-list { grid-template-columns: repeat(2, 1fr); }
 }
-@media (max-width: 620px) {
-  .shell { width: min(calc(100% - 22px), var(--content)); }
+@media (max-width: 680px) {
+  .shell { width: min(calc(100% - 20px), var(--content)); }
   .site-header { padding-top: 10px; }
-  .header-inner { border-radius: 20px; align-items: flex-start; }
-  .header-links { flex-direction: column; align-items: flex-end; }
+  .header-inner { align-items: flex-start; border-radius: 20px; }
+  .header-links { flex-direction: column; align-items: stretch; }
   main { padding-top: 38px; }
-  h1 { font-size: 2.8rem; }
+  h1 { font-size: 2.7rem; }
   .section { margin-top: 48px; }
   .section-heading { align-items: flex-start; flex-direction: column; }
-  .toolbar { width: 100%; }
-  .search { width: 100%; }
-  .case-card { grid-column: 1 / -1; min-height: 0; }
-  .process-grid, .report-list { grid-template-columns: 1fr; }
+  .catalogue-controls { grid-template-columns: 1fr; }
+  .control-search { grid-column: auto; }
+  .card-facts, .process-grid, .report-list { grid-template-columns: 1fr; }
   .report-heading, .report-body { padding: 20px; }
   .footer-inner { flex-direction: column; }
 }
-
+@media (max-width: 360px) {
+  .header-inner { padding: 10px; }
+  h1 { font-size: 2.25rem; }
+  .case-card { padding: 17px; }
+}
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; }
 }

--- a/web/static/site.js
+++ b/web/static/site.js
@@ -1,9 +1,18 @@
 (() => {
   const search = document.querySelector("[data-case-search]");
+  const purposeFilter = document.querySelector("[data-purpose-filter]");
+  const freshnessFilter = document.querySelector("[data-freshness-filter]");
   const caseItems = [...document.querySelectorAll("[data-case-item]")];
   const count = document.querySelector("[data-result-count]");
+  const summary = document.querySelector("[data-filter-summary]");
+  const emptyState = document.querySelector("[data-empty-state]");
+  const clearButtons = [
+    document.querySelector("[data-clear-filters]"),
+    document.querySelector("[data-empty-clear]"),
+  ].filter(Boolean);
   const viewButtons = [...document.querySelectorAll("[data-view-button]")];
   const views = [...document.querySelectorAll("[data-case-view]")];
+  const purposeSections = [...document.querySelectorAll("[data-purpose-section]")];
 
   const caseGroups = new Map();
   caseItems.forEach((item) => {
@@ -13,14 +22,76 @@
     caseGroups.get(slug).push(item);
   });
 
-  const filterCases = () => {
+  const validView = (value) =>
+    views.some((view) => view.dataset.caseView === value) ? value : "table";
+
+  const readState = () => {
+    const params = new URLSearchParams(window.location.search);
+    return {
+      q: params.get("q") || "",
+      purpose: params.get("purpose") || "all",
+      freshness: params.get("freshness") || "all",
+      view: validView(params.get("view") || "table"),
+    };
+  };
+
+  const currentState = () => ({
+    q: search?.value.trim() || "",
+    purpose: purposeFilter?.value || "all",
+    freshness: freshnessFilter?.value || "all",
+    view:
+      viewButtons.find((button) => button.getAttribute("aria-pressed") === "true")
+        ?.dataset.viewButton || "table",
+  });
+
+  const writeState = (state, { push = false } = {}) => {
+    const params = new URLSearchParams();
+    if (state.q) params.set("q", state.q);
+    if (state.purpose !== "all") params.set("purpose", state.purpose);
+    if (state.freshness !== "all") params.set("freshness", state.freshness);
+    if (state.view !== "table") params.set("view", state.view);
+    const next = `${window.location.pathname}${params.size ? `?${params}` : ""}${window.location.hash}`;
+    window.history[push ? "pushState" : "replaceState"](state, "", next);
+  };
+
+  const setView = (viewName, { persist = true } = {}) => {
+    if (!views.length) return;
+    const selected = validView(viewName);
+    views.forEach((view) => {
+      view.hidden = view.dataset.caseView !== selected;
+    });
+    viewButtons.forEach((button) => {
+      button.setAttribute("aria-pressed", String(button.dataset.viewButton === selected));
+    });
+    if (persist) writeState({ ...currentState(), view: selected });
+  };
+
+  const updatePurposeSections = () => {
+    purposeSections.forEach((section) => {
+      const visibleCards = [...section.querySelectorAll("[data-case-card]")].filter(
+        (card) => !card.hidden,
+      );
+      section.hidden = visibleCards.length === 0;
+      const sectionCount = section.querySelector("[data-purpose-count]");
+      if (sectionCount) sectionCount.textContent = `${visibleCards.length}件`;
+    });
+  };
+
+  const filterCases = ({ persist = true } = {}) => {
     if (!caseGroups.size) return;
-    const query = search?.value.trim().toLocaleLowerCase("ja") ?? "";
+    const state = currentState();
+    const query = state.q.toLocaleLowerCase("ja");
     let visible = 0;
 
     caseGroups.forEach((items) => {
-      const searchable = items[0]?.dataset.search ?? "";
-      const match = !query || searchable.includes(query);
+      const source = items[0];
+      const searchable = source?.dataset.search || "";
+      const purpose = source?.dataset.purpose || "";
+      const freshness = source?.dataset.freshness || "";
+      const matchQuery = !query || searchable.includes(query);
+      const matchPurpose = state.purpose === "all" || purpose === state.purpose;
+      const matchFreshness = state.freshness === "all" || freshness === state.freshness;
+      const match = matchQuery && matchPurpose && matchFreshness;
       items.forEach((item) => {
         item.hidden = !match;
       });
@@ -28,52 +99,55 @@
     });
 
     if (count) count.textContent = `${visible}件`;
+    if (emptyState) emptyState.hidden = visible !== 0;
+    updatePurposeSections();
+
+    const parts = [];
+    if (state.q) parts.push(`検索「${state.q}」`);
+    if (state.purpose !== "all") parts.push(state.purpose);
+    if (state.freshness === "current") parts.push("最新基準日");
+    if (state.freshness === "archive") parts.push("過去基準日");
+    if (summary) summary.textContent = parts.length ? `${parts.join("・")}で絞り込み` : "全テーマを表示中";
+    if (persist) writeState(state);
   };
 
-  const setView = (viewName) => {
-    if (!views.length) return;
-    const selected = views.some((view) => view.dataset.caseView === viewName)
-      ? viewName
-      : "table";
-
-    views.forEach((view) => {
-      view.hidden = view.dataset.caseView !== selected;
-    });
-    viewButtons.forEach((button) => {
-      button.setAttribute(
-        "aria-pressed",
-        String(button.dataset.viewButton === selected),
-      );
-    });
-
-    try {
-      window.localStorage.setItem("crewtrade-case-view", selected);
-    } catch {
-      // Storage can be disabled; the table remains the deterministic default.
+  const applyState = (state, { persist = false } = {}) => {
+    if (search) search.value = state.q;
+    if (purposeFilter) {
+      purposeFilter.value = [...purposeFilter.options].some((option) => option.value === state.purpose)
+        ? state.purpose
+        : "all";
     }
+    if (freshnessFilter) {
+      freshnessFilter.value = [...freshnessFilter.options].some(
+        (option) => option.value === state.freshness,
+      )
+        ? state.freshness
+        : "all";
+    }
+    setView(state.view, { persist: false });
+    filterCases({ persist });
   };
 
-  if (search && caseGroups.size) {
-    search.addEventListener("input", filterCases);
-  }
+  const clearFilters = () => {
+    applyState({ q: "", purpose: "all", freshness: "all", view: currentState().view });
+    search?.focus();
+  };
 
-  if (viewButtons.length && views.length) {
-    let initialView = "table";
-    try {
-      initialView = window.localStorage.getItem("crewtrade-case-view") || "table";
-    } catch {
-      initialView = "table";
-    }
+  search?.addEventListener("input", () => filterCases());
+  purposeFilter?.addEventListener("change", () => filterCases());
+  freshnessFilter?.addEventListener("change", () => filterCases());
+  clearButtons.forEach((button) => button.addEventListener("click", clearFilters));
 
-    viewButtons.forEach((button) => {
-      button.addEventListener("click", () => {
-        setView(button.dataset.viewButton || "table");
-      });
+  viewButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      setView(button.dataset.viewButton || "table");
+      filterCases();
     });
-    setView(initialView);
-  }
+  });
 
-  filterCases();
+  window.addEventListener("popstate", () => applyState(readState()));
+  applyState(readState(), { persist: true });
 
   const reportSelect = document.querySelector("[data-report-select]");
   if (reportSelect) {

--- a/web/templates/static_index.html
+++ b/web/templates/static_index.html
@@ -3,116 +3,161 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="CrewTradeの金融調査・時系列分析レポートを、テーマ、更新日、検証軸から閲覧できる公開ワークスペースです。">
-  <title>CrewTrade | Financial Research Workspace</title>
+  <meta name="description" content="CrewTradeの金融調査を、検証目的、対象、期間、更新状態、主要警告から選べる公開研究カタログです。">
+  <meta name="theme-color" content="#fbfaf7">
+  <title>CrewTrade | 金融調査カタログ</title>
   <link rel="stylesheet" href="assets/site.css">
   <link rel="stylesheet" href="assets/table.css">
   <script defer src="assets/site.js"></script>
 </head>
 <body>
+  <a class="skip-link" href="#research-catalogue">調査カタログへ移動</a>
   <header class="site-header shell">
     <div class="header-inner">
       <a class="brand" href="index.html" aria-label="CrewTrade ホーム">
-        <span class="brand-mark">CT</span><span>CrewTrade</span>
+        <span class="brand-mark" aria-hidden="true">CT</span><span>CrewTrade</span>
       </a>
-      <nav class="header-links" aria-label="外部リンク">
-        <a href="#research-map">調査テーマ</a>
+      <nav class="header-links" aria-label="主要ナビゲーション">
+        <a href="#research-catalogue">調査を選ぶ</a>
+        <a href="#reading-protocol">読み方</a>
         <a href="https://github.com/KAFKA2306/CrewTrade">GitHub</a>
       </nav>
     </div>
   </header>
 
   <main class="shell">
-    <section class="hero">
+    <section class="hero" aria-labelledby="page-title">
       <div>
-        <p class="eyebrow">Financial research workspace</p>
-        <h1>数字と解釈を、混ぜずに読む。</h1>
-        <p class="hero-copy">市場データ、計算結果、予測、文章による解釈を分離し、テーマごとの問いからレポートと根拠へ進むための公開ワークスペースです。</p>
+        <p class="eyebrow">Decision-oriented research catalogue</p>
+        <h1 id="page-title">何を検証するかから、調査を選ぶ。</h1>
+        <p class="hero-copy">テーマ名ではなく、検証目的、対象、期間、更新時点、主要な注意事項を先に確認します。数値、モデル予測、文章による解釈は同じ証拠として扱いません。</p>
         <div class="metrics" aria-label="公開状況">
           <span class="metric"><strong>{{ cases|length }}</strong>調査テーマ</span>
           <span class="metric"><strong>{{ total_reports }}</strong>公開レポート</span>
-          <span class="metric">静的スナップショット</span>
+          <span class="metric"><strong>{{ purposes|length }}</strong>検証目的</span>
+          <span class="metric">最新 {{ site_latest_date_label }}</span>
         </div>
       </div>
-      <aside class="hero-note">
-        <strong>このサイトの前提</strong>
-        <p>掲載値は各レポートの作成日時点です。リアルタイム価格、投資助言、将来収益の保証ではありません。</p>
+      <aside class="hero-note" aria-label="利用上の注意">
+        <span class="status-label">STATIC SNAPSHOT</span>
+        <strong>これはリアルタイム画面ではありません</strong>
+        <p>各カードの更新日と警告を確認してください。掲載内容は投資助言、売買推奨、将来収益の保証ではありません。</p>
       </aside>
     </section>
 
-    <section class="section" id="research-map">
+    <section class="section catalogue" id="research-catalogue" tabindex="-1" aria-labelledby="catalogue-title">
       <div class="section-heading">
         <div>
-          <p class="eyebrow">Research map</p>
-          <h2>問いから分析を選ぶ</h2>
-          <p>銘柄名の羅列ではなく、検証したい構造で整理しています。</p>
-        </div>
-        <div class="toolbar">
-          <input class="search" type="search" placeholder="テーマ・問いを検索" aria-label="調査テーマを検索" data-case-search>
-          <div class="view-switch" role="group" aria-label="一覧表示を切り替え">
-            <button class="view-button" type="button" data-view-button="table" aria-pressed="true">表</button>
-            <button class="view-button" type="button" data-view-button="cards" aria-pressed="false">カード</button>
-          </div>
-          <span class="result-count" data-result-count aria-live="polite">{{ cases|length }}件</span>
+          <p class="eyebrow">Research catalogue</p>
+          <h2 id="catalogue-title">調査テーマ</h2>
+          <p>検索条件はURLに保存され、再読込、共有、戻る操作で復元されます。</p>
         </div>
       </div>
 
-      <div class="case-table-shell" data-case-view="table">
+      <form class="catalogue-controls" data-case-controls role="search" aria-label="調査テーマを絞り込む">
+        <label class="control-field control-search" for="case-search">
+          <span>検索</span>
+          <input id="case-search" class="search" type="search" placeholder="問い、対象、テーマ、警告を検索" autocomplete="off" data-case-search>
+        </label>
+        <label class="control-field" for="purpose-filter">
+          <span>検証目的</span>
+          <select id="purpose-filter" data-purpose-filter>
+            <option value="all">すべて</option>
+            {% for purpose in purposes %}<option value="{{ purpose }}">{{ purpose }}</option>{% endfor %}
+          </select>
+        </label>
+        <label class="control-field" for="freshness-filter">
+          <span>更新状態</span>
+          <select id="freshness-filter" data-freshness-filter>
+            <option value="all">すべて</option>
+            <option value="current">最新基準日</option>
+            <option value="archive">過去基準日</option>
+          </select>
+        </label>
+        <div class="control-field">
+          <span>表示</span>
+          <div class="view-switch" role="group" aria-label="一覧表示を切り替え">
+            <button class="view-button" type="button" data-view-button="table" aria-pressed="true">比較表</button>
+            <button class="view-button" type="button" data-view-button="cards" aria-pressed="false">目的別カード</button>
+          </div>
+        </div>
+        <button class="clear-button" type="button" data-clear-filters>条件をリセット</button>
+      </form>
+
+      <div class="active-summary" aria-live="polite">
+        <strong data-result-count>{{ cases|length }}件</strong>
+        <span data-filter-summary>全テーマを表示中</span>
+      </div>
+
+      <div class="empty-state" data-empty-state hidden>
+        <h3>条件に一致する調査がありません</h3>
+        <p>検索語または絞り込み条件を変更してください。</p>
+        <button type="button" data-empty-clear>すべて表示</button>
+      </div>
+
+      <div class="case-table-shell" data-case-view="table" tabindex="0" aria-label="調査テーマ比較表。横方向にスクロールできます。">
         <table class="case-table">
+          <caption>検証目的、対象、期間、更新状態、警告を比較する調査テーマ一覧</caption>
           <thead>
             <tr>
               <th scope="col">調査テーマ</th>
-              <th scope="col">分類</th>
-              <th scope="col">検証軸</th>
-              <th scope="col" class="number-column">レポート</th>
+              <th scope="col">検証目的</th>
+              <th scope="col">対象・期間</th>
+              <th scope="col">状態・警告</th>
               <th scope="col">最新更新</th>
+              <th scope="col" class="number-column">レポート</th>
             </tr>
           </thead>
           <tbody>
             {% for case in cases %}
-            <tr data-case-item data-case-row data-case-slug="{{ case.slug }}" data-search="{{ (case.title ~ ' ' ~ case.category ~ ' ' ~ case.summary ~ ' ' ~ case.question)|lower }}">
+            <tr data-case-item data-case-row data-case-slug="{{ case.slug }}" data-purpose="{{ case.purpose }}" data-freshness="{{ case.freshness }}" data-search="{{ (case.title ~ ' ' ~ case.category ~ ' ' ~ case.purpose ~ ' ' ~ case.scope ~ ' ' ~ case.period ~ ' ' ~ case.summary ~ ' ' ~ case.question ~ ' ' ~ case.status ~ ' ' ~ case.warning)|lower }}">
               <td>
                 <a class="table-title" href="{{ case.slug }}/index.html" data-accent="{{ case.accent }}">
                   <span class="table-accent" aria-hidden="true"></span>
-                  <span><strong>{{ case.title }}</strong><small>{{ case.summary }}</small></span>
+                  <span><strong>{{ case.title }}</strong><small>{{ case.question }}</small></span>
                 </a>
               </td>
-              <td><span class="category-pill">{{ case.category }}</span></td>
-              <td class="table-question">{{ case.question }}</td>
+              <td><span class="category-pill">{{ case.purpose }}</span><small class="cell-secondary">{{ case.category }}</small></td>
+              <td><strong>{{ case.scope }}</strong><small class="cell-secondary">{{ case.period }}</small></td>
+              <td><span class="status-pill">{{ case.status }}</span><small class="cell-warning">{{ case.warning }}</small></td>
+              <td><a class="table-date" href="{{ case.slug }}/{{ case.latest_date }}.html">{{ case.latest_date_label }} <span aria-hidden="true">→</span></a><small class="cell-secondary">{{ case.change_summary }}</small></td>
               <td class="number-column"><strong>{{ case.report_count }}</strong></td>
-              <td><a class="table-date" href="{{ case.slug }}/{{ case.latest_date }}.html">{{ case.latest_date_label }} <span aria-hidden="true">→</span></a></td>
             </tr>
             {% endfor %}
           </tbody>
         </table>
       </div>
 
-      <div class="case-grid" data-case-view="cards" hidden>
-        {% for case in cases %}
-        <a class="case-card" href="{{ case.slug }}/index.html" data-case-item data-case-card data-case-slug="{{ case.slug }}" data-accent="{{ case.accent }}" data-search="{{ (case.title ~ ' ' ~ case.category ~ ' ' ~ case.summary ~ ' ' ~ case.question)|lower }}">
-          <div class="card-meta"><span>{{ case.category }}</span><span>{{ case.report_count }} reports</span></div>
-          <h3>{{ case.title }}</h3>
-          <p>{{ case.summary }}</p>
-          <p class="card-question">{{ case.question }}</p>
-          <span class="card-arrow">{{ case.latest_date_label }} →</span>
-        </a>
+      <div class="purpose-groups" data-case-view="cards" hidden>
+        {% for purpose in purposes %}
+        <section class="purpose-section" data-purpose-section="{{ purpose }}" aria-labelledby="purpose-{{ loop.index }}">
+          <div class="purpose-heading"><h3 id="purpose-{{ loop.index }}">{{ purpose }}</h3><span data-purpose-count></span></div>
+          <div class="case-grid">
+            {% for case in cases if case.purpose == purpose %}
+            <article class="case-card" data-case-item data-case-card data-case-slug="{{ case.slug }}" data-purpose="{{ case.purpose }}" data-freshness="{{ case.freshness }}" data-accent="{{ case.accent }}" data-search="{{ (case.title ~ ' ' ~ case.category ~ ' ' ~ case.purpose ~ ' ' ~ case.scope ~ ' ' ~ case.period ~ ' ' ~ case.summary ~ ' ' ~ case.question ~ ' ' ~ case.status ~ ' ' ~ case.warning)|lower }}">
+              <div class="card-meta"><span>{{ case.category }}</span><span class="status-pill">{{ case.status }}</span></div>
+              <h4><a href="{{ case.slug }}/index.html">{{ case.title }}</a></h4>
+              <p class="card-question"><span>検証する問い</span>{{ case.question }}</p>
+              <dl class="card-facts"><div><dt>対象</dt><dd>{{ case.scope }}</dd></div><div><dt>期間</dt><dd>{{ case.period }}</dd></div></dl>
+              <p class="card-warning"><strong>注意</strong>{{ case.warning }}</p>
+              <div class="card-footer"><a href="{{ case.slug }}/{{ case.latest_date }}.html">最新 {{ case.latest_date_label }}</a><span>{{ case.report_count }}件</span></div>
+            </article>
+            {% endfor %}
+          </div>
+        </section>
         {% endfor %}
       </div>
+      <noscript><p class="notice">JavaScriptが無効なため、検索と表示切替は利用できません。比較表から全テーマを閲覧できます。</p></noscript>
     </section>
 
-    <section class="section">
-      <div class="section-heading">
-        <div>
-          <p class="eyebrow">Reading protocol</p>
-          <h2>レポートの読み方</h2>
-        </div>
-      </div>
+    <section class="section" id="reading-protocol" aria-labelledby="protocol-title">
+      <div class="section-heading"><div><p class="eyebrow">Reading protocol</p><h2 id="protocol-title">レポートの読み方</h2></div></div>
       <div class="process-grid">
         <div class="process-step"><span>01</span><h3>対象と期間</h3><p>銘柄、指数、通貨、取得日、比較期間を最初に固定します。</p></div>
-        <div class="process-step"><span>02</span><h3>計算条件</h3><p>配当、分割、手数料、税、欠損、インサンプル/OOSを確認します。</p></div>
-        <div class="process-step"><span>03</span><h3>解釈と限界</h3><p>定量結果、モデル予測、LLMの文章を別の証拠レイヤーとして読みます。</p></div>
+        <div class="process-step"><span>02</span><h3>計算と証拠</h3><p>配当、分割、費用、欠損、実績、予測、OOSを分離します。</p></div>
+        <div class="process-step"><span>03</span><h3>警告と反証</h3><p>結論だけでなく、成立しない条件と更新時点を確認します。</p></div>
       </div>
-      <div class="notice"><strong>再現性:</strong> 公開ページはリポジトリ内の分析スナップショットから生成されます。生成器は曖昧な複数Markdownや出力欠損を成功扱いしません。</div>
+      <div class="notice"><strong>再現性:</strong> 公開ページはリポジトリ内の分析スナップショットから生成されます。曖昧な複数Markdown、出力欠損、未登録メタデータを正常状態として隠しません。</div>
     </section>
   </main>
 

--- a/web/templates/static_report.html
+++ b/web/templates/static_report.html
@@ -3,33 +3,48 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="{{ case.title }} — {{ date|report_date }}の分析レポート。">
+  <meta name="description" content="{{ case.title }} — {{ date|report_date }}の対象、期間、警告付き分析レポート。">
+  <meta name="theme-color" content="#fbfaf7">
   <title>{{ case.title }} — {{ date|report_date }} | CrewTrade</title>
   <link rel="stylesheet" href="../assets/site.css">
   <script defer src="../assets/site.js"></script>
 </head>
 <body>
+  <a class="skip-link" href="#report-content">レポート本文へ移動</a>
   <header class="site-header shell">
     <div class="header-inner">
-      <a class="brand" href="../index.html"><span class="brand-mark">CT</span><span>CrewTrade</span></a>
-      <nav class="header-links"><a href="index.html">レポート一覧</a><a href="https://github.com/KAFKA2306/CrewTrade">GitHub</a></nav>
+      <a class="brand" href="../index.html"><span class="brand-mark" aria-hidden="true">CT</span><span>CrewTrade</span></a>
+      <nav class="header-links" aria-label="主要ナビゲーション"><a href="index.html">レポート一覧</a><a href="#report-content">本文</a><a href="https://github.com/KAFKA2306/CrewTrade">GitHub</a></nav>
     </div>
   </header>
   <main class="shell">
-    <nav class="breadcrumbs" aria-label="パンくず"><a href="../index.html">CrewTrade</a><span>/</span><a href="index.html">{{ case.title }}</a><span>/</span><span>{{ date|report_date }}</span></nav>
+    <nav class="breadcrumbs" aria-label="パンくず"><a href="../index.html">CrewTrade</a><span aria-hidden="true">/</span><a href="index.html">{{ case.title }}</a><span aria-hidden="true">/</span><span aria-current="page">{{ date|report_date }}</span></nav>
     <div class="report-layout">
-      <aside class="report-sidebar">
+      <aside class="report-sidebar" aria-label="レポート情報">
         <label for="report-date">スナップショット</label>
         <select id="report-date" data-report-select>
           {% for item in dates %}<option value="{{ item }}.html"{% if item == date %} selected{% endif %}>{{ item|report_date }}</option>{% endfor %}
         </select>
-        <dl><dt>テーマ</dt><dd>{{ case.title }}</dd><dt>分類</dt><dd>{{ case.category }}</dd><dt>生成元</dt><dd>{{ source_name }}</dd></dl>
-        <a class="card-arrow" href="index.html">← 一覧へ戻る</a>
+        <dl>
+          <dt>検証目的</dt><dd>{{ case.purpose }}</dd>
+          <dt>テーマ</dt><dd>{{ case.title }}</dd>
+          <dt>対象</dt><dd>{{ case.scope }}</dd>
+          <dt>期間</dt><dd>{{ case.period }}</dd>
+          <dt>状態</dt><dd>{{ case.status }}</dd>
+          <dt>生成元</dt><dd>{{ source_name }}</dd>
+        </dl>
+        <p class="card-warning"><strong>主要な注意</strong>{{ case.warning }}</p>
+        <a class="card-arrow" href="index.html">← 履歴へ戻る</a>
       </aside>
       <div class="report-panel">
-        <header class="report-heading"><p class="eyebrow">Analysis snapshot</p><h1>{{ case.title }}</h1><p>{{ date|report_date }} · 掲載値は作成時点のスナップショットです。</p></header>
-        <article class="report-body">{{ content | safe }}</article>
-        <div class="notice"><strong>解釈上の注意:</strong> 過去の成績とモデル予測は将来の収益を保証しません。本文の対象期間、比較条件、欠損処理、評価区間を優先してください。</div>
+        <header class="report-heading">
+          <p class="eyebrow">Analysis snapshot · {{ case.category }}</p>
+          <h1>{{ case.title }}</h1>
+          <p>{{ date|report_date }} · 掲載値は作成時点の静的スナップショットです。</p>
+          <div class="metrics"><span class="metric">問い {{ case.question }}</span><span class="metric">状態 {{ case.status }}</span></div>
+        </header>
+        <article class="report-body" id="report-content" tabindex="-1">{{ content | safe }}</article>
+        <div class="notice"><strong>解釈上の注意:</strong> 過去の成績とモデル予測は将来の収益を保証しません。本文の対象期間、比較条件、データ時点、欠損処理、評価区間、反証条件を優先してください。</div>
       </div>
     </div>
   </main>

--- a/web/templates/static_use_case.html
+++ b/web/templates/static_use_case.html
@@ -3,54 +3,56 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="{{ case.title }}の公開分析レポート一覧。">
+  <meta name="description" content="{{ case.title }}の対象、期間、警告、公開分析レポート一覧。">
+  <meta name="theme-color" content="#fbfaf7">
   <title>{{ case.title }} | CrewTrade</title>
   <link rel="stylesheet" href="../assets/site.css">
   <link rel="stylesheet" href="../assets/table.css">
   <script defer src="../assets/site.js"></script>
 </head>
 <body style="--case-accent: var(--{{ case.accent }});">
+  <a class="skip-link" href="#report-history">レポート履歴へ移動</a>
   <header class="site-header shell">
     <div class="header-inner">
-      <a class="brand" href="../index.html"><span class="brand-mark">CT</span><span>CrewTrade</span></a>
-      <nav class="header-links"><a href="../index.html">全テーマ</a><a href="https://github.com/KAFKA2306/CrewTrade">GitHub</a></nav>
+      <a class="brand" href="../index.html"><span class="brand-mark" aria-hidden="true">CT</span><span>CrewTrade</span></a>
+      <nav class="header-links" aria-label="主要ナビゲーション"><a href="../index.html">全テーマ</a><a href="#report-history">履歴</a><a href="https://github.com/KAFKA2306/CrewTrade">GitHub</a></nav>
     </div>
   </header>
   <main class="shell">
-    <nav class="breadcrumbs" aria-label="パンくず"><a href="../index.html">CrewTrade</a><span>/</span><span>{{ case.title }}</span></nav>
-    <section class="case-hero">
+    <nav class="breadcrumbs" aria-label="パンくず"><a href="../index.html">CrewTrade</a><span aria-hidden="true">/</span><span aria-current="page">{{ case.title }}</span></nav>
+    <section class="case-hero" aria-labelledby="case-title">
       <div>
-        <p class="eyebrow">{{ case.category }}</p>
-        <h1>{{ case.title }}</h1>
+        <p class="eyebrow">{{ case.purpose }} · {{ case.category }}</p>
+        <h1 id="case-title">{{ case.title }}</h1>
         <p class="case-summary">{{ case.summary }}</p>
-        <div class="metrics"><span class="metric"><strong>{{ dates|length }}</strong>公開レポート</span><span class="metric">最新 {{ dates[0]|report_date }}</span></div>
+        <div class="metrics"><span class="metric"><strong>{{ dates|length }}</strong>公開レポート</span><span class="metric">最新 {{ dates[0]|report_date }}</span><span class="metric">状態 {{ case.status }}</span></div>
       </div>
-      <aside class="question-box"><small>この分析の検証軸</small><strong>{{ case.question }}</strong></aside>
+      <aside class="question-box" aria-label="分析の前提">
+        <small>検証する問い</small><strong>{{ case.question }}</strong>
+        <dl class="card-facts"><div><dt>対象</dt><dd>{{ case.scope }}</dd></div><div><dt>期間</dt><dd>{{ case.period }}</dd></div></dl>
+        <p class="card-warning"><strong>主要な注意</strong>{{ case.warning }}</p>
+      </aside>
     </section>
 
-    <section class="section">
-      <div class="section-heading"><div><p class="eyebrow">Reports</p><h2>分析スナップショット</h2><p>作成日ごとの条件と結論の変化を、時系列の表で追えます。</p></div></div>
-      <div class="report-table-shell">
+    <section class="section" id="report-history" tabindex="-1" aria-labelledby="history-title">
+      <div class="section-heading"><div><p class="eyebrow">Reports</p><h2 id="history-title">分析スナップショット</h2><p>作成日ごとの条件と結論を時系列で確認します。最新という理由だけで正式評価とは扱いません。</p></div></div>
+      <div class="report-table-shell" tabindex="0" aria-label="レポート履歴表。横方向にスクロールできます。">
         <table class="report-table">
-          <thead>
-            <tr>
-              <th scope="col">作成日</th>
-              <th scope="col">位置づけ</th>
-              <th scope="col">スナップショット</th>
-            </tr>
-          </thead>
+          <caption>{{ case.title }}の公開レポート履歴</caption>
+          <thead><tr><th scope="col">作成日</th><th scope="col">位置づけ</th><th scope="col">確認事項</th><th scope="col">スナップショット</th></tr></thead>
           <tbody>
             {% for date in dates %}
             <tr{% if loop.first %} class="latest-row"{% endif %}>
               <td><strong>{{ date|report_date }}</strong></td>
               <td>{% if loop.first %}<span class="status-pill latest-status">最新</span>{% else %}<span class="status-pill">履歴</span>{% endif %}</td>
+              <td>{% if loop.first %}{{ case.change_summary }}{% else %}当時の対象期間、計算条件、結論を本文で確認{% endif %}</td>
               <td><a class="report-open" href="{{ date }}.html">レポートを開く <span aria-hidden="true">→</span></a></td>
             </tr>
             {% endfor %}
           </tbody>
         </table>
       </div>
-      <div class="notice"><strong>注意:</strong> 日付はレポートのスナップショット識別子です。本文でデータ取得日と対象期間を確認してください。</div>
+      <div class="notice"><strong>注意:</strong> 日付はレポートのスナップショット識別子です。本文のデータ取得日、対象期間、比較条件、欠損処理を優先してください。</div>
     </section>
   </main>
   <footer class="site-footer shell"><div class="footer-inner"><span>CrewTrade / {{ case.title }}</span><span>Research, not recommendation.</span></div></footer>


### PR DESCRIPTION
## What changed

- replaces the generic theme index with a Japanese decision-oriented research catalogue
- groups themes by verification purpose and exposes scope, period, status, warning, latest snapshot, report count, and change summary
- adds search, purpose, freshness, and view filters with URL restoration and browser history support
- adds skip links, landmarks, visible focus, 44px controls, empty states, mobile reflow, and reduced-motion handling
- upgrades theme and report pages with explicit research context and warning boundaries
- extends the generated-site manifest and static audit to require the new metadata and accessibility structure
- adds a GitHub Actions workflow that compiles, builds, audits, and regenerates `docs/` after merge

## Root cause

The checked-in Pages output was still a directory-style English card list even though the repository already contained richer catalogue metadata and a newer generator. Users could not choose a report by question, scope, period, freshness, or risk, and filter state was not shareable.

## Validation

The passing PR workflow ran:

- `uv sync`
- Python source compilation
- `node --check web/static/site.js`
- `uv run python web/build_static.py`
- `uv run python web/audit_static.py`

On `main`, the same workflow commits the regenerated `docs/` output automatically.

Closes #14