### PR TITLE
Build CrewTrade canonical primary-data platform

### DIFF
--- a/.github/workflows/data-platform.yml
+++ b/.github/workflows/data-platform.yml
@@ -1,0 +1,105 @@
+name: Validate canonical data platform
+
+on:
+  pull_request:
+    paths:
+      - "crew/data_platform/**"
+      - "config/data_platform.yaml"
+      - "tests/data_platform/**"
+      - "docs/data-platform.md"
+      - "pyproject.toml"
+      - "Taskfile.yaml"
+      - ".github/workflows/data-platform.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crew/data_platform/**"
+      - "config/data_platform.yaml"
+      - "tests/data_platform/**"
+      - "pyproject.toml"
+      - "Taskfile.yaml"
+  workflow_dispatch:
+    inputs:
+      live_sync:
+        description: Fetch public primary sources and upload a snapshot artifact
+        type: boolean
+        default: false
+  schedule:
+    - cron: "17 5 * * *"
+      timezone: "Asia/Tokyo"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: data-platform-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.11"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Compile platform code
+        run: uv run python -m compileall -q crew/data_platform tests/data_platform
+
+      - name: Validate source registry
+        run: uv run crew-data validate-config
+
+      - name: Run offline contracts
+        run: uv run pytest tests/data_platform -q
+
+      - name: Exercise credential-free registry ingestion
+        run: uv run crew-data --root /tmp/crewtrade-platform sync --source governed_manual
+
+  live-snapshot:
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.live_sync)
+    needs: contracts
+    runs-on: ubuntu-latest
+    env:
+      FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
+      SEC_USER_AGENT: ${{ secrets.SEC_USER_AGENT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.11"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Require declared source credentials
+        run: |
+          test -n "$FRED_API_KEY" || { echo "FRED_API_KEY is required"; exit 1; }
+          test -n "$SEC_USER_AGENT" || { echo "SEC_USER_AGENT is required"; exit 1; }
+
+      - name: Fetch canonical public sources
+        run: uv run crew-data sync
+
+      - name: Show ingestion state
+        run: uv run crew-data status
+
+      - name: Upload non-canonical snapshot artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: crewtrade-data-platform-${{ github.run_id }}
+          path: data/platform
+          retention-days: 30
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ uv.lock
 
 # Database
 *.sqlite3
+*.duckdb
+*.duckdb.wal
 
 # Cache
 .ruff_cache/

--- a/README.md
+++ b/README.md
@@ -1,87 +1,90 @@
 # CrewTrade — 金融調査ワークスペース
 
-[公開ダッシュボード](https://kafka2306.github.io/CrewTrade/) · [GitHub Actions](https://github.com/KAFKA2306/CrewTrade/actions)
+[公開ダッシュボード](https://kafka2306.github.io/CrewTrade/) · [GitHub Actions](https://github.com/KAFKA2306/CrewTrade/actions) · [データ基盤設計](docs/data-platform.md)
 
-CrewTradeは、市場データの取得、定量計算、時系列予測、文章による解釈をユースケース単位で実行し、分析スナップショットとして公開する研究プロジェクトです。
+CrewTradeは、一次データの取得、定量計算、時系列予測、文章による解釈を分離し、分析スナップショットとして公開する研究プロジェクトです。
 
-公開画面は、レポート名の一覧ではなく、**何を検証する分析なのか**を起点に設計しています。対象・期間・計算条件・予測・解釈を同じ証拠として扱わず、レポート本文でそれぞれ確認できる状態を目指します。
+公開画面は、レポート名の一覧ではなく、**何を検証する分析なのか**を起点に設計しています。対象・期間・計算条件・予測・解釈を同じ証拠として扱いません。
+
+## 正準データ基盤
+
+ユースケース別のダウンロードファイルを正本とする方式から、次の共通基盤へ移行しています。
+
+```text
+一次API・統制された非公開入力
+  → immutable raw response + SHA-256
+  → normalized Parquet
+  → DuckDB catalogue / quality / lineage
+  → use-case analysis / reports
+```
+
+自動取得対象はFRED、米財務省、SEC EDGARです。JPX、EDINET、fundnote、LBMA、WSTS、証券担保契約は、利用権・機械取得可否・秘密性を `config/data_platform.yaml` に明示し、取得不能を推測で補完しません。
+
+```bash
+uv sync
+uv run crew-data validate-config
+uv run pytest tests/data_platform -q
+
+export FRED_API_KEY=...
+export SEC_USER_AGENT='CrewTrade contact@example.com'
+uv run crew-data sync
+uv run crew-data status
+```
+
+`data/platform/` にはraw、bronze Parquet、run manifest、`catalog.duckdb` が保存されます。GitHub Actions artifactは検証用スナップショットであり、正準保存先ではありません。運用時はDagu、WSL、コンテナなどの永続ボリュームで実行します。
 
 ## 公開画面
 
-- 調査テーマを「運用評価」「資産配分」「リスク管理」「産業分析」などの検証目的で整理
-- テーマ、問い、説明文を横断検索
-- 各テーマの最新スナップショットと公開レポート数を表示
-- 日付別レポートを切り替えて、前提や結論の変化を追跡
-- レポート画像・添付物を日付別アセットへ分離し、同名ファイルの上書きを防止
-- 掲載値がリアルタイムではないこと、投資助言ではないことを画面内に明示
-
-デザインは、背景 `#fbfaf7`、本文 `#243653`、青 `#8fb5ec`、ラベンダー `#b9a8e6`、ローズ `#efb4c1`、ミント `#b7dbc8`、アプリコット `#f3cfaa` を基調としています。
+- 調査テーマを検証目的で整理
+- テーマ、問い、対象、期間、警告を横断検索
+- 最新スナップショット、評価状態、レポート数を表示
+- 日付別レポートから前提や結論の変化を追跡
+- 数値、モデル予測、LLM解釈を別の証拠として表示
+- 掲載値がリアルタイムではないこと、投資助言ではないことを明示
 
 ## 調査テーマ
 
 | 公開スラッグ | 表示名 | 主な検証軸 |
 | --- | --- | --- |
-| `imura` | ファンド・指数比較 | 比較条件とリスクをそろえても超過収益が残るか |
-| `index_7_portfolio` | 7指数ポートフォリオ | 分散が実際の下落局面で機能したか |
+| `credit` | クレジット・スプレッド | 信用リスクへの追加補償は悪化余地に見合うか |
+| `imura` | ファンド・指数比較 | 条件とリスクをそろえても超過収益が残るか |
+| `index_7_portfolio` | 7指数ポートフォリオ | 分散が実際の下落局面で機能するか |
 | `index_etf_comparison` | 指数ETF比較 | 同じ指数名でも投資結果を分ける条件は何か |
 | `legendary_investors` | 著名投資家リサーチ | 公開情報から再現可能な判断原則を抽出できるか |
-| `oracle` | 個別企業・時系列予測 | 予測がアウト・オブ・サンプルでも情報を持つか |
+| `oracle` | Oracle実績・予測監査 | 受注残が売上とキャッシュへ転換するか |
 | `precious_metals_spread` | 貴金属スプレッド | 価格差が平均回帰か構造変化か |
 | `securities_collateral_loan` | 証券担保ローン | どの下落率から意思決定の自由が失われるか |
-| `semiconductors` | 半導体サイクル | 利益成長が数量・価格・能力のどこから生じたか |
-| `yield_spread` | 金利・イールドスプレッド | 金利差の変化がどの期待を反映しているか |
-
-未登録の出力ディレクトリは削除せず、「未分類」として表示します。名称や説明を推測で補完しません。
+| `semiconductors` | 半導体サイクル | 利益成長が数量・価格・能力のどこから生じるか |
+| `yield_spread` | 金利・イールドスプレッド | 金利差がどの期待とリスクプレミアムを反映するか |
 
 ## ディレクトリ構造
 
 ```text
+config/data_platform.yaml   一次データ源・利用権・更新契約
 config/use_cases/           ユースケース設定
-output/use_cases/           分析結果の正本
-  <use_case>/<YYYYMMDD>/
-    report.md               公開対象Markdown
-    *.png / *.csv / ...     レポート添付物
-web/
-  catalog.py                表示名・分類・検証軸の定義
-  build_static.py           GitHub Pages生成器
-  audit_static.py           生成物監査
-  static/                   共通CSS・JavaScript
-  templates/                Jinjaテンプレート
-docs/                       生成された静的サイト
+crew/data_platform/         取得・raw保存・Parquet・DuckDB・品質検査
+                               sources/  FRED / Treasury / SEC / governed manual
+                               cli.py    crew-data CLI
+                               storage.py immutable lake + catalogue
+                               quality.py common quality gates
+data/platform/              正準データ（Git管理外）
+output/use_cases/           公開分析結果の正本
+web/                        GitHub Pages生成器・静的監査
+docs/                       生成された公開サイトと設計文書
+tests/data_platform/        ネットワーク非依存の契約試験
 ```
-
-分析結果の正本は `output/use_cases/` です。`docs/` は `web/build_static.py` から再生成されます。
-
-## 公開ロジック
-
-1. `output/use_cases/<use_case>/<date>/` を列挙
-2. 公開対象Markdownを決定
-3. テーマ情報を `web/catalog.py` から付与
-4. MarkdownをHTMLへ変換
-5. 添付物を `docs/<use_case>/assets/<date>/` へコピー
-6. `docs/site-manifest.json` に公開テーマと日付を記録
-7. `web/audit_static.py` で言語設定、テンプレート残存、旧UI残存を検査
-8. GitHub Pagesへデプロイ
-
-同一日付ディレクトリに複数のMarkdownがあり、`report.md` または `analysis_report.md` で公開対象を一意に決められない場合、ビルドは失敗します。曖昧なファイルを任意に選んで成功扱いしません。
-
-## セットアップ
-
-```bash
-uv sync
-```
-
-Python要件は `>=3.11,<3.12` です。依存関係の正本は `pyproject.toml` です。
-
-APIキーや外部サービスの認証情報は環境変数または非公開設定で管理し、リポジトリへコミットしないでください。
 
 ## 実行
 
 ```bash
-task process:all   # データ取得から分析まで実行
-task fetch:all     # データ取得
-task run           # 分析実行
-task serve         # ローカルWeb画面
+task data:validate
+task data:test
+task data:sync:registry   # 外部認証不要
+task data:sync:public     # FRED_API_KEY / SEC_USER_AGENT 必須
+task data:status
+
+task process:all          # 移行期間中の既存パイプラインと分析
+task serve                # ローカルWeb画面
 ```
 
 静的サイトのみを生成・監査する場合:
@@ -91,32 +94,23 @@ uv run python web/build_static.py
 uv run python web/audit_static.py
 ```
 
-CLIエントリポイント:
-
-```bash
-uv run crew
-uv run run_crew
-uv run train
-uv run replay
-uv run test
-```
-
 ## 分析品質の確認項目
 
-- データの対象期間と取得日時を残す
-- 配当、分割、通貨、市場休業日の扱いを明示する
-- インサンプルとアウト・オブ・サンプルを分離する
+- データ対象期間、取得日時、公開日時、改訂ビンテージを残す
+- 原文レスポンスとSHA-256を保存する
+- 通貨、単位、配当、分割、市場休業日、ライセンスを明示する
 - 比較指数と計算条件をそろえる
+- インサンプルとアウト・オブ・サンプルを分離する
 - 手数料、税、スリッページを含まない結果を実績と呼ばない
-- 予測モデルの入力期間、予測期間、評価指標を保存する
+- 予測入力期間、予測期間、評価指標を保存する
 - LLMによる文章と定量計算結果を区別する
-- 取得失敗や欠損を推測で補完しない
+- 取得失敗、欠損、利用権未確認を推測で補完しない
 
 ## 注意
 
 - 掲載値は各レポート作成日時点のスナップショットです
 - 過去の成績は将来の収益を保証しません
-- Chronosなどの予測値は確定的な将来価格ではありません
+- 予測値は確定的な将来価格ではありません
 - 本プロジェクトは投資助言、売買推奨、運用実績の保証ではありません
 
-**最終構造監査:** 2026-08-02
+**最終構造監査:** 2026-08-04

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -7,8 +7,37 @@ tasks:
       - task: fetch:all
       - task: analyze:all
 
+  data:validate:
+    desc: Validate canonical data platform configuration
+    cmd: uv run crew-data validate-config
+
+  data:test:
+    desc: Run offline data platform contract tests
+    cmd: uv run pytest tests/data_platform -q
+
+  data:sync:
+    desc: Sync all enabled canonical primary sources
+    cmd: uv run crew-data sync
+
+  data:sync:public:
+    desc: Sync FRED, Treasury, SEC, and governed source registry
+    cmd: >-
+      uv run crew-data sync
+      --source fred
+      --source treasury_yield_curve
+      --source sec_edgar
+      --source governed_manual
+
+  data:sync:registry:
+    desc: Materialize the governed source registry without external credentials
+    cmd: uv run crew-data sync --source governed_manual
+
+  data:status:
+    desc: Show canonical ingestion runs and datasets
+    cmd: uv run crew-data status
+
   fetch:all:
-    desc: Run all data fetchers
+    desc: Run all legacy data fetchers during migration to the canonical platform
     cmds:
       - task: fetch:imura
       - task: fetch:oracle

--- a/config/data_platform.yaml
+++ b/config/data_platform.yaml
@@ -1,0 +1,123 @@
+schema_version: 1
+storage:
+  root: data/platform
+  canonical_timezone: UTC
+
+sources:
+  fred:
+    adapter: fred
+    enabled: true
+    api_key_env: FRED_API_KEY
+    user_agent: CrewTrade data-platform
+    min_interval_seconds: 0.25
+    datasets:
+      credit_oas:
+        observation_start: "1996-12-31"
+        series:
+          us_corporate_oas: BAMLC0A0CM
+          us_bbb_oas: BAMLC0A4CBBB
+          us_high_yield_oas: BAMLH0A0HYM2
+      rates_macro:
+        observation_start: "2003-01-01"
+        series:
+          us_2y: DGS2
+          us_10y: DGS10
+          us_30y: DGS30
+          us_10y_real: DFII10
+          us_10y_breakeven: T10YIE
+
+  treasury_yield_curve:
+    adapter: treasury_yield_curve
+    enabled: true
+    user_agent: CrewTrade data-platform
+    min_interval_seconds: 0.5
+    dataset: treasury_par_yield_curve
+    years: [2024, 2025, 2026]
+
+  sec_edgar:
+    adapter: sec
+    enabled: true
+    user_agent_env: SEC_USER_AGENT
+    min_interval_seconds: 0.15
+    entities:
+      oracle:
+        cik: "1341439"
+        companyfacts: true
+      soros_fund_management:
+        cik: "1029160"
+        companyfacts: false
+      duquesne_family_office:
+        cik: "1536411"
+        companyfacts: false
+
+  governed_manual:
+    adapter: governed_manual
+    enabled: true
+    registry_url: https://github.com/KAFKA2306/CrewTrade/blob/main/config/data_platform.yaml
+    datasets:
+      fundnote_kaihou:
+        use_cases: [imura]
+        owner: fundnote株式会社
+        source_url: https://www.fundnote.co.jp/fund/kaihou/
+        access_mode: official_document
+        license_status: public_reference_only
+        refresh_policy: monthly_or_material_event
+        required_fields: [nav_date, nav, distribution, fee_revision, purchase_status]
+        automation_status: blocked
+        block_reason: Machine-readable official NAV history endpoint not yet contracted.
+        checked_on: "2026-08-04"
+      jpx_etf_master:
+        use_cases: [index_etf_comparison, index_7_portfolio, securities_collateral_loan]
+        owner: 株式会社日本取引所グループ
+        source_url: https://www.jpx.co.jp/equities/products/etfs/issues/index.html
+        access_mode: official_document
+        license_status: terms_review_required
+        refresh_policy: daily_metadata_monthly_full
+        required_fields: [ticker, isin, official_name, index_name, currency, hedge, fee, inception_date]
+        automation_status: blocked
+        block_reason: Product master and market data redistribution terms must be recorded before ingestion.
+        checked_on: "2026-08-04"
+      edinet_api_v2:
+        use_cases: [index_etf_comparison, semiconductors, oracle]
+        owner: 金融庁
+        source_url: https://disclosure2dl.edinet-fsa.go.jp/guide/static/disclosure/WEEK0060.html
+        access_mode: official_api
+        license_status: public_api_key_required
+        refresh_policy: daily
+        required_fields: [doc_id, edinet_code, sec_code, form_code, submit_datetime, xbrl_sha256]
+        automation_status: ready_requires_adapter_and_secret
+        block_reason: EDINET_API_KEY and XBRL normalization adapter are not yet configured.
+        checked_on: "2026-08-04"
+      lbma_benchmarks:
+        use_cases: [precious_metals_spread]
+        owner: London Bullion Market Association
+        source_url: https://www.lbma.org.uk/prices-and-data/lbma-precious-metal-prices
+        access_mode: licensed_benchmark
+        license_status: license_required_for_history_and_redistribution
+        refresh_policy: daily_after_license
+        required_fields: [benchmark, fixing, currency, unit, observation_time, value]
+        automation_status: blocked
+        block_reason: Historical benchmark storage and redistribution require a recorded license.
+        checked_on: "2026-08-04"
+      wsts_market_data:
+        use_cases: [semiconductors]
+        owner: World Semiconductor Trade Statistics
+        source_url: https://www.wsts.org/
+        access_mode: public_release_plus_member_data
+        license_status: mixed
+        refresh_policy: monthly_public_release_quarterly_forecast
+        required_fields: [vintage_date, period, product_group, geography, value, status]
+        automation_status: partial
+        block_reason: Public releases can be snapshotted; detailed member tables require access rights.
+        checked_on: "2026-08-04"
+      broker_collateral_contract:
+        use_cases: [securities_collateral_loan]
+        owner: user_private
+        source_url: https://github.com/KAFKA2306/CrewTrade
+        access_mode: private_contract
+        license_status: private_not_publishable
+        refresh_policy: on_contract_or_collateral_change
+        required_fields: [contract_version, valuation_time, ticker, quantity, market_price, collateral_haircut]
+        automation_status: private_input_required
+        block_reason: Contract and account state must remain outside the public repository.
+        checked_on: "2026-08-04"

--- a/crew/data_platform/__init__.py
+++ b/crew/data_platform/__init__.py
@@ -1,0 +1,12 @@
+from crew.data_platform.contracts import DatasetBatch, PersistedBatch, QualityCheck
+from crew.data_platform.registry import load_config, sync
+from crew.data_platform.storage import DataPlatformStorage
+
+__all__ = [
+    "DataPlatformStorage",
+    "DatasetBatch",
+    "PersistedBatch",
+    "QualityCheck",
+    "load_config",
+    "sync",
+]

--- a/crew/data_platform/__main__.py
+++ b/crew/data_platform/__main__.py
@@ -1,0 +1,5 @@
+from crew.data_platform.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crew/data_platform/cli.py
+++ b/crew/data_platform/cli.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import duckdb
+
+from crew.data_platform.registry import load_config, sync
+
+
+DEFAULT_CONFIG = Path("config/data_platform.yaml")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="crew-data",
+        description="CrewTrade canonical primary-data platform",
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--root", type=Path, default=None)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    sync_parser = subparsers.add_parser("sync", help="Fetch and persist sources")
+    sync_parser.add_argument(
+        "--source",
+        action="append",
+        dest="sources",
+        help="Source name from config/data_platform.yaml; repeatable",
+    )
+
+    subparsers.add_parser("status", help="Show recent ingestion runs and datasets")
+
+    query_parser = subparsers.add_parser("query", help="Run a read-only DuckDB query")
+    query_parser.add_argument("sql")
+
+    subparsers.add_parser("validate-config", help="Validate configuration only")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = load_config(args.config)
+    root = args.root or Path(config["storage"]["root"])
+
+    if args.command == "validate-config":
+        source_count = len(config.get("sources", {}))
+        print(f"Config valid: schema_version=1, sources={source_count}, root={root}")
+        return 0
+
+    if args.command == "sync":
+        run_id, persisted, manifest = sync(
+            config_path=args.config,
+            selected_sources=args.sources,
+            root_override=args.root,
+        )
+        print(f"Run {run_id} succeeded: {len(persisted)} batches")
+        for batch in persisted:
+            print(
+                f"- {batch.dataset}: rows={batch.row_count} "
+                f"sha256={batch.raw_sha256[:16]} parquet={batch.parquet_path}"
+            )
+        print(f"Manifest: {manifest}")
+        return 0
+
+    catalog = root / "catalog.duckdb"
+    if not catalog.exists():
+        raise FileNotFoundError(
+            f"Catalogue does not exist: {catalog}. Run `crew-data sync` first."
+        )
+
+    if args.command == "status":
+        with duckdb.connect(str(catalog), read_only=True) as connection:
+            runs = connection.execute(
+                """
+                SELECT run_id, started_at, completed_at, status, error
+                FROM ingestion_runs
+                ORDER BY started_at DESC
+                LIMIT 20
+                """
+            ).fetchdf()
+            datasets = connection.execute(
+                """
+                SELECT dataset, source, count(*) AS files, sum(row_count) AS rows,
+                       max(retrieved_at) AS latest_retrieved_at
+                FROM dataset_files
+                GROUP BY dataset, source
+                ORDER BY dataset, source
+                """
+            ).fetchdf()
+        print("Recent runs")
+        print(runs.to_string(index=False))
+        print("\nDatasets")
+        print(datasets.to_string(index=False))
+        return 0
+
+    if args.command == "query":
+        sql = args.sql.strip()
+        first_token = sql.split(maxsplit=1)[0].lower() if sql else ""
+        if first_token not in {"select", "with", "show", "describe", "pragma"}:
+            raise ValueError("Only read-only SQL is accepted by the CLI.")
+        with duckdb.connect(str(catalog), read_only=True) as connection:
+            result = connection.execute(sql).fetchdf()
+        print(result.to_string(index=False))
+        return 0
+
+    raise AssertionError(f"Unhandled command: {args.command}")

--- a/crew/data_platform/contracts.py
+++ b/crew/data_platform/contracts.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping, Protocol, Sequence
+
+import pandas as pd
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class HttpPayload:
+    body: bytes
+    url: str
+    status_code: int
+    content_type: str
+    retrieved_at: datetime
+    headers: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DatasetBatch:
+    """One immutable ingestion result and its normalized tabular representation."""
+
+    dataset: str
+    source: str
+    frame: pd.DataFrame
+    primary_key: tuple[str, ...]
+    source_url: str
+    raw_payload: bytes
+    content_type: str = "application/octet-stream"
+    retrieved_at: datetime = field(default_factory=utc_now)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class QualityCheck:
+    name: str
+    passed: bool
+    details: str
+
+
+@dataclass(frozen=True)
+class PersistedBatch:
+    dataset: str
+    source: str
+    row_count: int
+    raw_path: str
+    parquet_path: str
+    raw_sha256: str
+    checks: Sequence[QualityCheck]
+
+
+class SourceAdapter(Protocol):
+    name: str
+
+    def fetch(self) -> Sequence[DatasetBatch]: ...

--- a/crew/data_platform/gold.py
+++ b/crew/data_platform/gold.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+
+
+_LATEST_BY_SERIES = {"credit_oas", "rates_macro"}
+
+
+def refresh_gold_views(catalog_path: Path) -> None:
+    """Create deterministic point-in-time views for datasets already in the catalogue."""
+
+    with duckdb.connect(str(catalog_path)) as connection:
+        datasets = {
+            row[0]
+            for row in connection.execute(
+                "SELECT DISTINCT dataset FROM dataset_files"
+            ).fetchall()
+        }
+        for dataset in sorted(_LATEST_BY_SERIES.intersection(datasets)):
+            connection.execute(
+                f"""
+                CREATE OR REPLACE VIEW gold_{dataset}_latest AS
+                SELECT * EXCLUDE (_rank)
+                FROM (
+                    SELECT *,
+                           row_number() OVER (
+                               PARTITION BY series_id
+                               ORDER BY observation_date DESC,
+                                        realtime_start DESC,
+                                        _retrieved_at DESC
+                           ) AS _rank
+                    FROM bronze_{dataset}
+                )
+                WHERE _rank = 1
+                """
+            )
+
+        if "treasury_par_yield_curve" in datasets:
+            connection.execute(
+                """
+                CREATE OR REPLACE VIEW gold_treasury_curve_latest AS
+                SELECT * EXCLUDE (_rank)
+                FROM (
+                    SELECT *,
+                           row_number() OVER (
+                               PARTITION BY tenor
+                               ORDER BY observation_date DESC, _retrieved_at DESC
+                           ) AS _rank
+                    FROM bronze_treasury_par_yield_curve
+                )
+                WHERE _rank = 1
+                """
+            )
+
+        if "sec_filings" in datasets:
+            connection.execute(
+                """
+                CREATE OR REPLACE VIEW gold_sec_filings_latest AS
+                SELECT * EXCLUDE (_rank)
+                FROM (
+                    SELECT *,
+                           row_number() OVER (
+                               PARTITION BY entity_cik, form
+                               ORDER BY filing_date DESC,
+                                        acceptance_datetime DESC,
+                                        _retrieved_at DESC
+                           ) AS _rank
+                    FROM bronze_sec_filings
+                )
+                WHERE _rank = 1
+                """
+            )
+
+        if "sec_company_facts" in datasets:
+            connection.execute(
+                """
+                CREATE OR REPLACE VIEW gold_sec_company_facts_latest AS
+                SELECT * EXCLUDE (_rank)
+                FROM (
+                    SELECT *,
+                           row_number() OVER (
+                               PARTITION BY entity_cik, taxonomy, concept, unit
+                               ORDER BY end_date DESC NULLS LAST,
+                                        filed_date DESC NULLS LAST,
+                                        _retrieved_at DESC
+                           ) AS _rank
+                    FROM bronze_sec_company_facts
+                )
+                WHERE _rank = 1
+                """
+            )

--- a/crew/data_platform/http.py
+++ b/crew/data_platform/http.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import time
+from datetime import timezone
+from email.utils import parsedate_to_datetime
+from typing import Mapping
+
+import requests
+
+from crew.data_platform.contracts import HttpPayload, utc_now
+
+
+class HttpClient:
+    """Small governed HTTP client with declared identity, retries, and rate limiting."""
+
+    def __init__(
+        self,
+        *,
+        user_agent: str,
+        min_interval_seconds: float = 0.15,
+        timeout_seconds: float = 30.0,
+        max_attempts: int = 4,
+    ) -> None:
+        if not user_agent.strip():
+            raise ValueError("A declared user agent is required for automated ingestion.")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "User-Agent": user_agent,
+                "Accept-Encoding": "gzip, deflate",
+                "Accept": "application/json, application/xml, text/xml, text/csv, */*",
+            }
+        )
+        self.min_interval_seconds = max(0.0, min_interval_seconds)
+        self.timeout_seconds = timeout_seconds
+        self.max_attempts = max_attempts
+        self._last_request_at = 0.0
+
+    def get(
+        self,
+        url: str,
+        *,
+        params: Mapping[str, object] | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> HttpPayload:
+        last_error: Exception | None = None
+        for attempt in range(1, self.max_attempts + 1):
+            self._throttle()
+            try:
+                response = self.session.get(
+                    url,
+                    params=params,
+                    headers=dict(headers or {}),
+                    timeout=self.timeout_seconds,
+                )
+                if response.status_code in {429, 500, 502, 503, 504}:
+                    if attempt == self.max_attempts:
+                        response.raise_for_status()
+                    time.sleep(self._retry_delay(response.headers, attempt))
+                    continue
+                response.raise_for_status()
+                retrieved_at = utc_now()
+                date_header = response.headers.get("Date")
+                if date_header:
+                    try:
+                        retrieved_at = parsedate_to_datetime(date_header).astimezone(
+                            timezone.utc
+                        )
+                    except (TypeError, ValueError, OverflowError):
+                        pass
+                return HttpPayload(
+                    body=response.content,
+                    url=response.url,
+                    status_code=response.status_code,
+                    content_type=response.headers.get(
+                        "Content-Type", "application/octet-stream"
+                    ),
+                    retrieved_at=retrieved_at,
+                    headers=dict(response.headers),
+                )
+            except requests.RequestException as error:
+                last_error = error
+                if attempt == self.max_attempts:
+                    raise
+                time.sleep(min(2**attempt, 20))
+        raise RuntimeError("HTTP request failed") from last_error
+
+    def _throttle(self) -> None:
+        elapsed = time.monotonic() - self._last_request_at
+        if elapsed < self.min_interval_seconds:
+            time.sleep(self.min_interval_seconds - elapsed)
+        self._last_request_at = time.monotonic()
+
+    @staticmethod
+    def _retry_delay(headers: Mapping[str, str], attempt: int) -> float:
+        retry_after = headers.get("Retry-After")
+        if retry_after:
+            try:
+                return min(float(retry_after), 60.0)
+            except ValueError:
+                pass
+        return min(2**attempt, 20)

--- a/crew/data_platform/quality.py
+++ b/crew/data_platform/quality.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import math
+from typing import Iterable
+from urllib.parse import urlparse
+
+import numpy as np
+import pandas as pd
+
+from crew.data_platform.contracts import DatasetBatch, QualityCheck
+
+
+def validate_batch(batch: DatasetBatch) -> list[QualityCheck]:
+    checks: list[QualityCheck] = []
+    frame = batch.frame
+
+    checks.append(
+        QualityCheck(
+            "non_empty",
+            not frame.empty,
+            f"rows={len(frame)}",
+        )
+    )
+
+    missing_keys = [key for key in batch.primary_key if key not in frame.columns]
+    checks.append(
+        QualityCheck(
+            "primary_key_columns",
+            not missing_keys,
+            "missing=" + ",".join(missing_keys) if missing_keys else "all present",
+        )
+    )
+
+    if not missing_keys and batch.primary_key:
+        null_key_rows = int(frame[list(batch.primary_key)].isna().any(axis=1).sum())
+        duplicate_rows = int(frame.duplicated(list(batch.primary_key), keep=False).sum())
+        checks.append(
+            QualityCheck(
+                "primary_key_not_null",
+                null_key_rows == 0,
+                f"null_key_rows={null_key_rows}",
+            )
+        )
+        checks.append(
+            QualityCheck(
+                "primary_key_unique",
+                duplicate_rows == 0,
+                f"duplicate_rows={duplicate_rows}",
+            )
+        )
+
+    parsed_url = urlparse(batch.source_url)
+    checks.append(
+        QualityCheck(
+            "source_url_https",
+            parsed_url.scheme == "https" and bool(parsed_url.netloc),
+            batch.source_url,
+        )
+    )
+    checks.append(
+        QualityCheck(
+            "raw_payload_present",
+            bool(batch.raw_payload),
+            f"bytes={len(batch.raw_payload)}",
+        )
+    )
+
+    numeric_columns = frame.select_dtypes(include=[np.number]).columns
+    invalid_numeric: list[str] = []
+    for column in numeric_columns:
+        values = frame[column].dropna().to_numpy()
+        if any(not math.isfinite(float(value)) for value in values):
+            invalid_numeric.append(str(column))
+    checks.append(
+        QualityCheck(
+            "finite_numeric_values",
+            not invalid_numeric,
+            "invalid=" + ",".join(invalid_numeric) if invalid_numeric else "all finite",
+        )
+    )
+
+    return checks
+
+
+def assert_quality(checks: Iterable[QualityCheck]) -> None:
+    failures = [check for check in checks if not check.passed]
+    if failures:
+        details = "; ".join(f"{item.name}: {item.details}" for item in failures)
+        raise ValueError(f"Data quality checks failed: {details}")

--- a/crew/data_platform/registry.py
+++ b/crew/data_platform/registry.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping, Sequence
 import yaml
 
 from crew.data_platform.contracts import PersistedBatch, SourceAdapter
+from crew.data_platform.gold import refresh_gold_views
 from crew.data_platform.sources import (
     FredSource,
     GovernedManualSource,
@@ -82,6 +83,7 @@ def sync(
         for adapter in adapters:
             for batch in adapter.fetch():
                 persisted.append(storage.persist(run_id, batch))
+        refresh_gold_views(storage.catalog_path)
         manifest_path = storage.write_manifest(run_id, persisted)
         storage.finish_run(run_id, status="success")
         return run_id, persisted, manifest_path

--- a/crew/data_platform/registry.py
+++ b/crew/data_platform/registry.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+from crew.data_platform.contracts import PersistedBatch, SourceAdapter
+from crew.data_platform.sources import (
+    FredSource,
+    GovernedManualSource,
+    SecSource,
+    TreasuryYieldCurveSource,
+)
+from crew.data_platform.storage import DataPlatformStorage
+
+
+_ADAPTERS = {
+    "fred": FredSource,
+    "treasury_yield_curve": TreasuryYieldCurveSource,
+    "sec": SecSource,
+    "governed_manual": GovernedManualSource,
+}
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Data platform config must be a mapping: {path}")
+    if payload.get("schema_version") != 1:
+        raise ValueError("Unsupported data platform schema_version")
+    return payload
+
+
+def build_adapters(
+    config: Mapping[str, Any], selected_sources: Sequence[str] | None = None
+) -> list[SourceAdapter]:
+    selected = set(selected_sources or [])
+    adapters: list[SourceAdapter] = []
+    for source_name, source_config_value in dict(config.get("sources", {})).items():
+        if selected and source_name not in selected:
+            continue
+        source_config = dict(source_config_value or {})
+        if not bool(source_config.get("enabled", False)):
+            continue
+        adapter_name = str(source_config.get("adapter", source_name))
+        adapter_class = _ADAPTERS.get(adapter_name)
+        if adapter_class is None:
+            raise ValueError(
+                f"Unknown adapter {adapter_name!r} for source {source_name!r}"
+            )
+        adapters.append(adapter_class(source_config))
+    if selected:
+        built_names = {
+            source_name
+            for source_name, source_config in dict(config.get("sources", {})).items()
+            if source_name in selected and bool(source_config.get("enabled", False))
+        }
+        missing = selected.difference(built_names)
+        if missing:
+            raise ValueError(f"Unknown or disabled sources: {sorted(missing)}")
+    return adapters
+
+
+def sync(
+    *,
+    config_path: Path,
+    selected_sources: Sequence[str] | None = None,
+    root_override: Path | None = None,
+) -> tuple[str, list[PersistedBatch], Path]:
+    config = load_config(config_path)
+    root = root_override or Path(config["storage"]["root"])
+    storage = DataPlatformStorage(root)
+    adapters = build_adapters(config, selected_sources)
+    requested = list(selected_sources or config.get("sources", {}).keys())
+    run_id = _new_run_id()
+    storage.start_run(run_id, requested)
+    persisted: list[PersistedBatch] = []
+    try:
+        for adapter in adapters:
+            for batch in adapter.fetch():
+                persisted.append(storage.persist(run_id, batch))
+        manifest_path = storage.write_manifest(run_id, persisted)
+        storage.finish_run(run_id, status="success")
+        return run_id, persisted, manifest_path
+    except Exception as error:
+        storage.finish_run(run_id, status="failed", error=str(error))
+        raise
+
+
+def _new_run_id() -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{timestamp}-{uuid.uuid4().hex[:8]}"

--- a/crew/data_platform/sources/__init__.py
+++ b/crew/data_platform/sources/__init__.py
@@ -1,0 +1,11 @@
+from crew.data_platform.sources.fred import FredSource
+from crew.data_platform.sources.manual import GovernedManualSource
+from crew.data_platform.sources.sec import SecSource
+from crew.data_platform.sources.treasury import TreasuryYieldCurveSource
+
+__all__ = [
+    "FredSource",
+    "GovernedManualSource",
+    "SecSource",
+    "TreasuryYieldCurveSource",
+]

--- a/crew/data_platform/sources/fred.py
+++ b/crew/data_platform/sources/fred.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Mapping, Sequence
+
+import pandas as pd
+
+from crew.data_platform.contracts import DatasetBatch
+from crew.data_platform.http import HttpClient
+
+
+class FredSource:
+    name = "fred"
+    BASE_URL = "https://api.stlouisfed.org/fred"
+
+    def __init__(self, config: Mapping[str, Any]) -> None:
+        self.config = config
+        api_key_env = str(config.get("api_key_env", "FRED_API_KEY"))
+        self.api_key = os.environ.get(api_key_env, "").strip()
+        if not self.api_key:
+            raise RuntimeError(f"FRED API key is required in {api_key_env}.")
+        self.client = HttpClient(
+            user_agent=str(config.get("user_agent", "CrewTrade data-platform")),
+            min_interval_seconds=float(config.get("min_interval_seconds", 0.25)),
+        )
+
+    def fetch(self) -> Sequence[DatasetBatch]:
+        batches: list[DatasetBatch] = []
+        for dataset_name, dataset_config in dict(self.config.get("datasets", {})).items():
+            rows: list[dict[str, object]] = []
+            raw_bundle: dict[str, object] = {"dataset": dataset_name, "series": {}}
+            latest_url = ""
+            latest_retrieved_at = None
+            series_map = dict(dataset_config.get("series", {}))
+            for label, series_id_value in series_map.items():
+                series_id = str(series_id_value)
+                metadata_payload = self.client.get(
+                    f"{self.BASE_URL}/series",
+                    params={
+                        "api_key": self.api_key,
+                        "file_type": "json",
+                        "series_id": series_id,
+                    },
+                )
+                observations_payload = self.client.get(
+                    f"{self.BASE_URL}/series/observations",
+                    params={
+                        "api_key": self.api_key,
+                        "file_type": "json",
+                        "series_id": series_id,
+                        "observation_start": dataset_config.get(
+                            "observation_start", "1900-01-01"
+                        ),
+                        "sort_order": "asc",
+                        "output_type": 1,
+                    },
+                )
+                metadata_json = json.loads(metadata_payload.body)
+                observations_json = json.loads(observations_payload.body)
+                raw_bundle["series"][series_id] = {
+                    "label": label,
+                    "metadata": metadata_json,
+                    "observations": observations_json,
+                }
+                rows.extend(
+                    parse_fred_series(
+                        label=label,
+                        series_id=series_id,
+                        metadata=metadata_json,
+                        observations=observations_json,
+                    )
+                )
+                latest_url = observations_payload.url
+                latest_retrieved_at = observations_payload.retrieved_at
+            frame = pd.DataFrame.from_records(rows)
+            batches.append(
+                DatasetBatch(
+                    dataset=str(dataset_name),
+                    source=self.name,
+                    frame=frame,
+                    primary_key=(
+                        "series_id",
+                        "observation_date",
+                        "realtime_start",
+                        "realtime_end",
+                    ),
+                    source_url=latest_url or f"{self.BASE_URL}/series/observations",
+                    raw_payload=json.dumps(
+                        raw_bundle, ensure_ascii=False, sort_keys=True
+                    ).encode("utf-8"),
+                    content_type="application/json",
+                    retrieved_at=latest_retrieved_at
+                    if latest_retrieved_at is not None
+                    else pd.Timestamp.utcnow().to_pydatetime(),
+                    metadata={"series_count": len(series_map)},
+                )
+            )
+        return batches
+
+
+def parse_fred_series(
+    *,
+    label: str,
+    series_id: str,
+    metadata: Mapping[str, Any],
+    observations: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    series_records = list(metadata.get("seriess", []))
+    series_meta = series_records[0] if series_records else {}
+    rows: list[dict[str, object]] = []
+    for observation in observations.get("observations", []):
+        value_text = str(observation.get("value", "."))
+        if value_text in {".", "", "nan", "NaN"}:
+            continue
+        rows.append(
+            {
+                "series_id": series_id,
+                "label": label,
+                "observation_date": pd.to_datetime(observation["date"]).date(),
+                "value": float(value_text),
+                "realtime_start": pd.to_datetime(
+                    observation.get("realtime_start")
+                ).date(),
+                "realtime_end": pd.to_datetime(
+                    observation.get("realtime_end")
+                ).date(),
+                "frequency": series_meta.get("frequency"),
+                "units": series_meta.get("units"),
+                "seasonal_adjustment": series_meta.get("seasonal_adjustment"),
+                "last_updated": series_meta.get("last_updated"),
+                "title": series_meta.get("title"),
+            }
+        )
+    return rows

--- a/crew/data_platform/sources/manual.py
+++ b/crew/data_platform/sources/manual.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Sequence
+
+import pandas as pd
+
+from crew.data_platform.contracts import DatasetBatch, utc_now
+
+
+class GovernedManualSource:
+    """Registers licensed, contractual, or human-supplied sources without fabricating data."""
+
+    name = "governed_manual"
+
+    def __init__(self, config: Mapping[str, Any]) -> None:
+        self.config = config
+
+    def fetch(self) -> Sequence[DatasetBatch]:
+        rows: list[dict[str, object]] = []
+        sources = dict(self.config.get("datasets", {}))
+        for source_id, source_config in sources.items():
+            rows.append(
+                {
+                    "source_id": str(source_id),
+                    "use_cases": json.dumps(
+                        source_config.get("use_cases", []), ensure_ascii=False
+                    ),
+                    "owner": source_config.get("owner"),
+                    "source_url": source_config.get("source_url"),
+                    "access_mode": source_config.get("access_mode", "manual"),
+                    "license_status": source_config.get(
+                        "license_status", "unverified"
+                    ),
+                    "refresh_policy": source_config.get("refresh_policy"),
+                    "required_fields": json.dumps(
+                        source_config.get("required_fields", []), ensure_ascii=False
+                    ),
+                    "automation_status": source_config.get(
+                        "automation_status", "blocked"
+                    ),
+                    "block_reason": source_config.get("block_reason"),
+                    "checked_on": pd.to_datetime(
+                        source_config.get("checked_on")
+                    ).date()
+                    if source_config.get("checked_on")
+                    else None,
+                }
+            )
+        frame = pd.DataFrame.from_records(rows)
+        raw_payload = json.dumps(
+            {"datasets": sources}, ensure_ascii=False, sort_keys=True
+        ).encode("utf-8")
+        return [
+            DatasetBatch(
+                dataset="governed_source_registry",
+                source=self.name,
+                frame=frame,
+                primary_key=("source_id",),
+                source_url=str(
+                    self.config.get(
+                        "registry_url",
+                        "https://github.com/KAFKA2306/CrewTrade/blob/main/config/data_platform.yaml",
+                    )
+                ),
+                raw_payload=raw_payload,
+                content_type="application/json",
+                retrieved_at=utc_now(),
+                metadata={"registered_sources": len(rows)},
+            )
+        ]

--- a/crew/data_platform/sources/sec.py
+++ b/crew/data_platform/sources/sec.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from typing import Any, Mapping, Sequence
+
+import pandas as pd
+
+from crew.data_platform.contracts import DatasetBatch
+from crew.data_platform.http import HttpClient
+
+
+class SecSource:
+    name = "sec_edgar"
+    DATA_BASE_URL = "https://data.sec.gov"
+
+    def __init__(self, config: Mapping[str, Any]) -> None:
+        self.config = config
+        user_agent_env = str(config.get("user_agent_env", "SEC_USER_AGENT"))
+        user_agent = os.environ.get(user_agent_env, "").strip()
+        if not user_agent:
+            raise RuntimeError(
+                f"SEC declared user agent is required in {user_agent_env}, "
+                "for example 'CrewTrade admin@example.com'."
+            )
+        self.client = HttpClient(
+            user_agent=user_agent,
+            min_interval_seconds=max(
+                0.12, float(config.get("min_interval_seconds", 0.15))
+            ),
+        )
+
+    def fetch(self) -> Sequence[DatasetBatch]:
+        filing_rows: list[dict[str, object]] = []
+        fact_rows: list[dict[str, object]] = []
+        raw_bundle: dict[str, object] = {"entities": {}}
+        latest_url = self.DATA_BASE_URL
+        latest_retrieved_at = None
+
+        for entity_name, entity_config in dict(self.config.get("entities", {})).items():
+            cik = str(entity_config["cik"]).zfill(10)
+            submissions_payload = self.client.get(
+                f"{self.DATA_BASE_URL}/submissions/CIK{cik}.json"
+            )
+            submissions_json = json.loads(submissions_payload.body)
+            filing_rows.extend(
+                parse_sec_submissions(
+                    entity_name=str(entity_name), cik=cik, payload=submissions_json
+                )
+            )
+            entity_raw: dict[str, object] = {"submissions": submissions_json}
+            latest_url = submissions_payload.url
+            latest_retrieved_at = submissions_payload.retrieved_at
+
+            if bool(entity_config.get("companyfacts", False)):
+                facts_payload = self.client.get(
+                    f"{self.DATA_BASE_URL}/api/xbrl/companyfacts/CIK{cik}.json"
+                )
+                facts_json = json.loads(facts_payload.body)
+                fact_rows.extend(
+                    parse_sec_companyfacts(
+                        entity_name=str(entity_name), cik=cik, payload=facts_json
+                    )
+                )
+                entity_raw["companyfacts"] = facts_json
+                latest_url = facts_payload.url
+                latest_retrieved_at = facts_payload.retrieved_at
+            raw_bundle["entities"][entity_name] = entity_raw
+
+        raw_payload = json.dumps(
+            raw_bundle, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        retrieved_at = (
+            latest_retrieved_at
+            if latest_retrieved_at is not None
+            else pd.Timestamp.utcnow().to_pydatetime()
+        )
+        batches: list[DatasetBatch] = []
+        if filing_rows:
+            batches.append(
+                DatasetBatch(
+                    dataset="sec_filings",
+                    source=self.name,
+                    frame=pd.DataFrame.from_records(filing_rows),
+                    primary_key=("entity_cik", "accession_number"),
+                    source_url=latest_url,
+                    raw_payload=raw_payload,
+                    content_type="application/json",
+                    retrieved_at=retrieved_at,
+                    metadata={"entity_count": len(self.config.get("entities", {}))},
+                )
+            )
+        if fact_rows:
+            batches.append(
+                DatasetBatch(
+                    dataset="sec_company_facts",
+                    source=self.name,
+                    frame=pd.DataFrame.from_records(fact_rows),
+                    primary_key=("fact_id",),
+                    source_url=latest_url,
+                    raw_payload=raw_payload,
+                    content_type="application/json",
+                    retrieved_at=retrieved_at,
+                    metadata={"entity_count": len(self.config.get("entities", {}))},
+                )
+            )
+        return batches
+
+
+def parse_sec_submissions(
+    *, entity_name: str, cik: str, payload: Mapping[str, Any]
+) -> list[dict[str, object]]:
+    recent = payload.get("filings", {}).get("recent", {})
+    accessions = list(recent.get("accessionNumber", []))
+    rows: list[dict[str, object]] = []
+    for index, accession_number in enumerate(accessions):
+        rows.append(
+            {
+                "entity_name": entity_name,
+                "entity_cik": cik,
+                "accession_number": accession_number,
+                "filing_date": _date_at(recent, "filingDate", index),
+                "report_date": _date_at(recent, "reportDate", index),
+                "acceptance_datetime": _timestamp_at(
+                    recent, "acceptanceDateTime", index
+                ),
+                "form": _value_at(recent, "form", index),
+                "primary_document": _value_at(recent, "primaryDocument", index),
+                "primary_doc_description": _value_at(
+                    recent, "primaryDocDescription", index
+                ),
+                "file_number": _value_at(recent, "fileNumber", index),
+                "is_xbrl": _value_at(recent, "isXBRL", index),
+                "is_inline_xbrl": _value_at(recent, "isInlineXBRL", index),
+            }
+        )
+    return rows
+
+
+def parse_sec_companyfacts(
+    *, entity_name: str, cik: str, payload: Mapping[str, Any]
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for taxonomy, concepts in dict(payload.get("facts", {})).items():
+        for concept, fact_definition in dict(concepts).items():
+            label = fact_definition.get("label")
+            description = fact_definition.get("description")
+            for unit, observations in dict(fact_definition.get("units", {})).items():
+                for observation in observations:
+                    canonical = {
+                        "entity_cik": cik,
+                        "taxonomy": taxonomy,
+                        "concept": concept,
+                        "unit": unit,
+                        "observation": observation,
+                    }
+                    fact_id = hashlib.sha256(
+                        json.dumps(
+                            canonical,
+                            ensure_ascii=False,
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ).encode("utf-8")
+                    ).hexdigest()
+                    rows.append(
+                        {
+                            "fact_id": fact_id,
+                            "entity_name": entity_name,
+                            "entity_cik": cik,
+                            "taxonomy": taxonomy,
+                            "concept": concept,
+                            "label": label,
+                            "description": description,
+                            "unit": unit,
+                            "value": observation.get("val"),
+                            "start_date": _to_date(observation.get("start")),
+                            "end_date": _to_date(observation.get("end")),
+                            "filed_date": _to_date(observation.get("filed")),
+                            "form": observation.get("form"),
+                            "fiscal_year": observation.get("fy"),
+                            "fiscal_period": observation.get("fp"),
+                            "frame": observation.get("frame"),
+                            "accession_number": observation.get("accn"),
+                        }
+                    )
+    return rows
+
+
+def _value_at(payload: Mapping[str, Any], key: str, index: int) -> object | None:
+    values = payload.get(key, [])
+    return values[index] if index < len(values) else None
+
+
+def _date_at(payload: Mapping[str, Any], key: str, index: int) -> object | None:
+    return _to_date(_value_at(payload, key, index))
+
+
+def _timestamp_at(payload: Mapping[str, Any], key: str, index: int) -> object | None:
+    value = _value_at(payload, key, index)
+    return pd.to_datetime(value, utc=True) if value else None
+
+
+def _to_date(value: object | None) -> object | None:
+    return pd.to_datetime(value).date() if value else None

--- a/crew/data_platform/sources/treasury.py
+++ b/crew/data_platform/sources/treasury.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Mapping, Sequence
+from xml.etree import ElementTree
+
+import pandas as pd
+
+from crew.data_platform.contracts import DatasetBatch
+from crew.data_platform.http import HttpClient
+
+
+_TENOR_FIELDS = {
+    "BC_1MONTH": "1M",
+    "BC_1_5MONTH": "1.5M",
+    "BC_2MONTH": "2M",
+    "BC_3MONTH": "3M",
+    "BC_4MONTH": "4M",
+    "BC_6MONTH": "6M",
+    "BC_1YEAR": "1Y",
+    "BC_2YEAR": "2Y",
+    "BC_3YEAR": "3Y",
+    "BC_5YEAR": "5Y",
+    "BC_7YEAR": "7Y",
+    "BC_10YEAR": "10Y",
+    "BC_20YEAR": "20Y",
+    "BC_30YEAR": "30Y",
+}
+
+
+class TreasuryYieldCurveSource:
+    name = "us_treasury"
+    URL = "https://home.treasury.gov/resource-center/data-chart-center/interest-rates/pages/xml"
+
+    def __init__(self, config: Mapping[str, Any]) -> None:
+        self.config = config
+        self.client = HttpClient(
+            user_agent=str(config.get("user_agent", "CrewTrade data-platform")),
+            min_interval_seconds=float(config.get("min_interval_seconds", 0.5)),
+        )
+
+    def fetch(self) -> Sequence[DatasetBatch]:
+        years = [int(value) for value in self.config.get("years", [])]
+        if not years:
+            years = [pd.Timestamp.utcnow().year]
+        rows: list[dict[str, object]] = []
+        raw_documents: list[dict[str, str]] = []
+        latest_url = self.URL
+        latest_retrieved_at = None
+        for year in sorted(set(years)):
+            payload = self.client.get(
+                self.URL,
+                params={
+                    "data": "daily_treasury_yield_curve",
+                    "field_tdr_date_value": year,
+                },
+            )
+            rows.extend(parse_treasury_yield_xml(payload.body))
+            raw_documents.append(
+                {
+                    "year": str(year),
+                    "url": payload.url,
+                    "body_base64": base64.b64encode(payload.body).decode("ascii"),
+                }
+            )
+            latest_url = payload.url
+            latest_retrieved_at = payload.retrieved_at
+        frame = pd.DataFrame.from_records(rows)
+        return [
+            DatasetBatch(
+                dataset=str(
+                    self.config.get("dataset", "treasury_par_yield_curve")
+                ),
+                source=self.name,
+                frame=frame,
+                primary_key=("observation_date", "tenor"),
+                source_url=latest_url,
+                raw_payload=json.dumps(
+                    {"documents": raw_documents}, ensure_ascii=False, sort_keys=True
+                ).encode("utf-8"),
+                content_type="application/json",
+                retrieved_at=latest_retrieved_at
+                if latest_retrieved_at is not None
+                else pd.Timestamp.utcnow().to_pydatetime(),
+                metadata={"years": years, "curve_type": "par_yield"},
+            )
+        ]
+
+
+def parse_treasury_yield_xml(payload: bytes) -> list[dict[str, object]]:
+    root = ElementTree.fromstring(payload)
+    rows: list[dict[str, object]] = []
+    for element in root.iter():
+        if _local_name(element.tag) != "properties":
+            continue
+        values = {
+            _local_name(child.tag): (child.text or "").strip()
+            for child in list(element)
+        }
+        date_text = values.get("NEW_DATE") or values.get("Id")
+        if not date_text:
+            continue
+        observation_date = pd.to_datetime(date_text).date()
+        for field, tenor in _TENOR_FIELDS.items():
+            value_text = values.get(field)
+            if not value_text:
+                continue
+            rows.append(
+                {
+                    "observation_date": observation_date,
+                    "tenor": tenor,
+                    "value": float(value_text),
+                    "unit": "percent",
+                    "curve_type": "daily_treasury_par_yield_curve",
+                }
+            )
+    return rows
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]

--- a/crew/data_platform/storage.py
+++ b/crew/data_platform/storage.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import duckdb
+
+from crew.data_platform.contracts import DatasetBatch, PersistedBatch, QualityCheck
+from crew.data_platform.quality import assert_quality, validate_batch
+
+
+_SAFE_NAME = re.compile(r"[^a-zA-Z0-9_]+")
+
+
+def _safe_name(value: str) -> str:
+    normalized = _SAFE_NAME.sub("_", value).strip("_").lower()
+    if not normalized:
+        raise ValueError(f"Unsafe empty dataset name derived from {value!r}")
+    return normalized
+
+
+class DataPlatformStorage:
+    """Immutable raw/Parquet storage with a small DuckDB control catalogue."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.raw_dir = root / "raw"
+        self.bronze_dir = root / "bronze"
+        self.manifest_dir = root / "manifests"
+        self.catalog_path = root / "catalog.duckdb"
+        for path in (self.raw_dir, self.bronze_dir, self.manifest_dir):
+            path.mkdir(parents=True, exist_ok=True)
+        self._initialize_catalog()
+
+    def start_run(self, run_id: str, requested_sources: Iterable[str]) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO ingestion_runs
+                    (run_id, started_at, status, requested_sources)
+                VALUES (?, ?, 'running', ?)
+                """,
+                [
+                    run_id,
+                    datetime.now(timezone.utc),
+                    json.dumps(sorted(set(requested_sources)), ensure_ascii=False),
+                ],
+            )
+
+    def finish_run(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        error: str | None = None,
+    ) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE ingestion_runs
+                SET completed_at = ?, status = ?, error = ?
+                WHERE run_id = ?
+                """,
+                [datetime.now(timezone.utc), status, error, run_id],
+            )
+
+    def persist(self, run_id: str, batch: DatasetBatch) -> PersistedBatch:
+        checks = validate_batch(batch)
+        self._record_checks(run_id, batch, checks)
+        assert_quality(checks)
+
+        dataset = _safe_name(batch.dataset)
+        source = _safe_name(batch.source)
+        raw_sha256 = hashlib.sha256(batch.raw_payload).hexdigest()
+        raw_suffix = self._raw_suffix(batch.content_type)
+        raw_path = (
+            self.raw_dir
+            / f"source={source}"
+            / f"dataset={dataset}"
+            / f"run_id={run_id}"
+            / f"payload-{raw_sha256[:16]}{raw_suffix}"
+        )
+        raw_path.parent.mkdir(parents=True, exist_ok=True)
+        raw_path.write_bytes(batch.raw_payload)
+
+        frame = batch.frame.copy()
+        frame["_run_id"] = run_id
+        frame["_retrieved_at"] = batch.retrieved_at
+        frame["_source_url"] = batch.source_url
+        frame["_raw_sha256"] = raw_sha256
+
+        parquet_path = (
+            self.bronze_dir
+            / f"dataset={dataset}"
+            / f"source={source}"
+            / f"run_id={run_id}"
+            / "part-000.parquet"
+        )
+        parquet_path.parent.mkdir(parents=True, exist_ok=True)
+        frame.to_parquet(parquet_path, index=False)
+
+        schema_json = json.dumps(
+            {column: str(dtype) for column, dtype in frame.dtypes.items()},
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        metadata_json = json.dumps(dict(batch.metadata), ensure_ascii=False, sort_keys=True)
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO dataset_files
+                    (run_id, dataset, source, row_count, raw_path, parquet_path,
+                     raw_sha256, source_url, retrieved_at, schema_json, metadata_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    run_id,
+                    dataset,
+                    source,
+                    len(frame),
+                    str(raw_path.relative_to(self.root)),
+                    str(parquet_path.relative_to(self.root)),
+                    raw_sha256,
+                    batch.source_url,
+                    batch.retrieved_at,
+                    schema_json,
+                    metadata_json,
+                ],
+            )
+        self.refresh_dataset_view(dataset)
+        return PersistedBatch(
+            dataset=dataset,
+            source=source,
+            row_count=len(frame),
+            raw_path=str(raw_path),
+            parquet_path=str(parquet_path),
+            raw_sha256=raw_sha256,
+            checks=checks,
+        )
+
+    def write_manifest(self, run_id: str, persisted: list[PersistedBatch]) -> Path:
+        manifest = {
+            "schema_version": 1,
+            "run_id": run_id,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "catalog": str(self.catalog_path),
+            "batches": [
+                {
+                    **asdict(batch),
+                    "checks": [asdict(check) for check in batch.checks],
+                }
+                for batch in persisted
+            ],
+        }
+        path = self.manifest_dir / f"{run_id}.json"
+        path.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def refresh_dataset_view(self, dataset: str) -> None:
+        dataset = _safe_name(dataset)
+        glob_path = (self.bronze_dir / f"dataset={dataset}" / "**" / "*.parquet").as_posix()
+        view_name = f"bronze_{dataset}"
+        with self._connect() as connection:
+            connection.execute(
+                f"""
+                CREATE OR REPLACE VIEW {view_name} AS
+                SELECT *
+                FROM read_parquet('{glob_path}', union_by_name=true, hive_partitioning=true)
+                """
+            )
+
+    def _record_checks(
+        self,
+        run_id: str,
+        batch: DatasetBatch,
+        checks: list[QualityCheck],
+    ) -> None:
+        with self._connect() as connection:
+            for check in checks:
+                connection.execute(
+                    """
+                    INSERT INTO quality_results
+                        (run_id, dataset, source, check_name, passed, details, checked_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    [
+                        run_id,
+                        batch.dataset,
+                        batch.source,
+                        check.name,
+                        check.passed,
+                        check.details,
+                        datetime.now(timezone.utc),
+                    ],
+                )
+
+    def _initialize_catalog(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ingestion_runs (
+                    run_id VARCHAR PRIMARY KEY,
+                    started_at TIMESTAMPTZ NOT NULL,
+                    completed_at TIMESTAMPTZ,
+                    status VARCHAR NOT NULL,
+                    requested_sources JSON NOT NULL,
+                    error VARCHAR
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS dataset_files (
+                    run_id VARCHAR NOT NULL,
+                    dataset VARCHAR NOT NULL,
+                    source VARCHAR NOT NULL,
+                    row_count BIGINT NOT NULL,
+                    raw_path VARCHAR NOT NULL,
+                    parquet_path VARCHAR NOT NULL,
+                    raw_sha256 VARCHAR NOT NULL,
+                    source_url VARCHAR NOT NULL,
+                    retrieved_at TIMESTAMPTZ NOT NULL,
+                    schema_json JSON NOT NULL,
+                    metadata_json JSON NOT NULL,
+                    PRIMARY KEY (run_id, dataset, source, parquet_path)
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS quality_results (
+                    run_id VARCHAR NOT NULL,
+                    dataset VARCHAR NOT NULL,
+                    source VARCHAR NOT NULL,
+                    check_name VARCHAR NOT NULL,
+                    passed BOOLEAN NOT NULL,
+                    details VARCHAR NOT NULL,
+                    checked_at TIMESTAMPTZ NOT NULL
+                )
+                """
+            )
+
+    def _connect(self) -> duckdb.DuckDBPyConnection:
+        return duckdb.connect(str(self.catalog_path))
+
+    @staticmethod
+    def _raw_suffix(content_type: str) -> str:
+        lowered = content_type.lower()
+        if "json" in lowered:
+            return ".json"
+        if "xml" in lowered:
+            return ".xml"
+        if "csv" in lowered:
+            return ".csv"
+        if "html" in lowered:
+            return ".html"
+        return ".bin"

--- a/docs/data-platform.md
+++ b/docs/data-platform.md
@@ -1,0 +1,110 @@
+# CrewTrade canonical data platform
+
+## Purpose
+
+CrewTrade no longer treats each use case's downloaded file as an independent source of truth. The canonical data platform preserves the original response, a normalized analytical table, lineage, quality results, and ingestion-run status before any report or model consumes the data.
+
+```text
+Official API / governed private input
+        ↓
+raw/      immutable response bytes + SHA-256
+        ↓
+bronze/   normalized Parquet, partitioned by dataset/source/run
+        ↓
+catalog.duckdb
+          ingestion_runs
+          dataset_files
+          quality_results
+          bronze_<dataset> views
+        ↓
+use-case exports / quantitative analysis / public reports
+```
+
+The default local root is `data/platform/`. It can be overridden with `crew-data --root <path>` or by passing a persistent mounted path from Dagu, a container, or WSL.
+
+## Storage contract
+
+Every accepted batch must retain:
+
+- source and dataset identifiers;
+- retrieval time and canonical HTTPS source URL;
+- raw response bytes and SHA-256;
+- normalized Parquet rows;
+- declared primary key;
+- schema and source metadata;
+- quality-check results;
+- immutable run manifest.
+
+A failed quality check aborts publication of that batch. Existing files are never silently overwritten because each write is partitioned by `run_id`.
+
+## Automated primary sources
+
+| Source | Datasets | Authentication | Notes |
+| --- | --- | --- | --- |
+| FRED / ALFRED | Credit OAS, nominal yields, real yields, breakeven inflation | `FRED_API_KEY` | Observations retain real-time start/end dates so revisions can be reconstructed. |
+| U.S. Treasury | Daily par-yield curve | none | Official XML is normalized to observation date, tenor, value and curve type. |
+| SEC EDGAR | Filing history and company facts | declared `SEC_USER_AGENT` | Requests are throttled below the SEC fair-access ceiling. Filing accession numbers and XBRL facts are point-in-time records. |
+
+## Governed sources that must not be guessed
+
+`config/data_platform.yaml` also registers sources that are public documents, licensed benchmarks, or private contracts. Their absence is represented as an explicit blocked or partial status rather than an invented value.
+
+- fundnote Kaihou NAV and notices;
+- JPX ETF product master and product terms;
+- EDINET API v2 and XBRL filings;
+- LBMA benchmark history;
+- WSTS public releases and member data;
+- private brokerage collateral contract and account state.
+
+The registry records ownership, access mode, licence state, refresh policy, required fields, and the exact reason automation is blocked.
+
+## Commands
+
+```bash
+uv sync
+uv run crew-data validate-config
+uv run pytest tests/data_platform -q
+
+# No external credentials required
+uv run crew-data sync --source governed_manual
+
+# Full public-source sync
+export FRED_API_KEY=...
+export SEC_USER_AGENT='CrewTrade contact@example.com'
+uv run crew-data sync \
+  --source fred \
+  --source treasury_yield_curve \
+  --source sec_edgar \
+  --source governed_manual
+
+uv run crew-data status
+uv run crew-data query 'select * from bronze_credit_oas order by observation_date desc limit 20'
+```
+
+Equivalent Task targets are `data:validate`, `data:test`, `data:sync`, `data:sync:public`, `data:sync:registry`, and `data:status`.
+
+## Runtime ownership
+
+The canonical production store should run on a persistent filesystem controlled by CrewTrade. GitHub Actions is used for contract tests and optional snapshot artifacts; an expiring Actions artifact is not the source of truth. A Dagu or local scheduled job should mount the persistent `DATA_PLATFORM_ROOT` and execute `task data:sync:public`.
+
+## Migration rule
+
+Legacy `data/<use_case>/` files and Yahoo-based clients remain temporarily available so current reports do not break. Migration proceeds dataset by dataset:
+
+1. ingest the official source into the canonical platform;
+2. compare canonical and legacy outputs for the same observation dates;
+3. implement an explicit export/view for the use case;
+4. switch the analysis to the canonical view;
+5. delete the legacy downloader only after parity and provenance checks pass.
+
+Credit and yield analyses must migrate first because their existing ETF-price proxies do not represent credit OAS or the Treasury term structure.
+
+## Primary specifications
+
+- FRED API overview: https://fred.stlouisfed.org/docs/api/fred/overview.html
+- FRED observations and vintages: https://fred.stlouisfed.org/docs/api/fred/series_observations.html
+- SEC EDGAR APIs: https://www.sec.gov/search-filings/edgar-application-programming-interfaces
+- SEC automated access: https://www.sec.gov/search-filings/edgar-search-assistance/accessing-edgar-data
+- EDINET API documentation: https://disclosure2dl.edinet-fsa.go.jp/guide/static/disclosure/WEEK0060.html
+- U.S. Treasury interest-rate data: https://home.treasury.gov/resource-center/data-chart-center/interest-rates
+- DuckDB Parquet querying: https://duckdb.org/docs/stable/data/parquet/overview

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dependencies = [
     "chronos-forecasting",
     "transformers",
     "accelerate",
+    "duckdb>=1.2,<2",
+    "pyyaml>=6,<7",
+    "python-dotenv>=1,<2",
+    "pytest>=8,<9",
 ]
 
 [project.scripts]
@@ -40,6 +44,7 @@ run_crew = "crew.main:run"
 train = "crew.main:train"
 replay = "crew.main:replay"
 test = "crew.main:test"
+crew-data = "crew.data_platform.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/data_platform/test_platform.py
+++ b/tests/data_platform/test_platform.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+import pytest
+
+from crew.data_platform.contracts import DatasetBatch
+from crew.data_platform.quality import assert_quality, validate_batch
+from crew.data_platform.sources.fred import parse_fred_series
+from crew.data_platform.sources.sec import (
+    parse_sec_companyfacts,
+    parse_sec_submissions,
+)
+from crew.data_platform.sources.treasury import parse_treasury_yield_xml
+from crew.data_platform.storage import DataPlatformStorage
+
+
+def test_quality_rejects_duplicate_primary_keys() -> None:
+    batch = DatasetBatch(
+        dataset="example",
+        source="fixture",
+        frame=pd.DataFrame(
+            [
+                {"date": "2026-01-01", "value": 1.0},
+                {"date": "2026-01-01", "value": 2.0},
+            ]
+        ),
+        primary_key=("date",),
+        source_url="https://example.com/data",
+        raw_payload=b"fixture",
+    )
+    checks = validate_batch(batch)
+    assert any(
+        check.name == "primary_key_unique" and not check.passed for check in checks
+    )
+    with pytest.raises(ValueError, match="primary_key_unique"):
+        assert_quality(checks)
+
+
+def test_storage_preserves_raw_lineage_and_creates_view(tmp_path: Path) -> None:
+    storage = DataPlatformStorage(tmp_path / "platform")
+    run_id = "20260804T000000Z-test"
+    storage.start_run(run_id, ["fixture"])
+    batch = DatasetBatch(
+        dataset="test_observations",
+        source="fixture",
+        frame=pd.DataFrame(
+            [
+                {"series_id": "X", "date": pd.Timestamp("2026-08-01").date(), "value": 1.25},
+                {"series_id": "X", "date": pd.Timestamp("2026-08-02").date(), "value": 1.50},
+            ]
+        ),
+        primary_key=("series_id", "date"),
+        source_url="https://example.com/fixture.json",
+        raw_payload=b'{"fixture":true}',
+        content_type="application/json",
+    )
+    persisted = storage.persist(run_id, batch)
+    manifest = storage.write_manifest(run_id, [persisted])
+    storage.finish_run(run_id, status="success")
+
+    assert Path(persisted.raw_path).read_bytes() == b'{"fixture":true}'
+    assert Path(persisted.parquet_path).is_file()
+    assert manifest.is_file()
+    with duckdb.connect(str(storage.catalog_path), read_only=True) as connection:
+        assert connection.execute("SELECT count(*) FROM bronze_test_observations").fetchone()[0] == 2
+        assert connection.execute("SELECT status FROM ingestion_runs").fetchone()[0] == "success"
+
+
+def test_parse_fred_series() -> None:
+    rows = parse_fred_series(
+        label="high_yield_oas",
+        series_id="BAMLH0A0HYM2",
+        metadata={
+            "seriess": [
+                {
+                    "frequency": "Daily",
+                    "units": "Percent",
+                    "seasonal_adjustment": "Not Seasonally Adjusted",
+                    "last_updated": "2026-08-03 09:00:00-05",
+                    "title": "ICE BofA US High Yield Index OAS",
+                }
+            ]
+        },
+        observations={
+            "observations": [
+                {
+                    "date": "2026-08-01",
+                    "value": "2.84",
+                    "realtime_start": "2026-08-04",
+                    "realtime_end": "2026-08-04",
+                },
+                {
+                    "date": "2026-08-02",
+                    "value": ".",
+                    "realtime_start": "2026-08-04",
+                    "realtime_end": "2026-08-04",
+                },
+            ]
+        },
+    )
+    assert len(rows) == 1
+    assert rows[0]["value"] == 2.84
+
+
+def test_parse_treasury_yield_xml() -> None:
+    payload = b"""<?xml version='1.0' encoding='utf-8'?>
+    <feed xmlns:m='http://schemas.microsoft.com/ado/2007/08/dataservices/metadata'
+          xmlns:d='http://schemas.microsoft.com/ado/2007/08/dataservices'>
+      <entry><content><m:properties>
+        <d:NEW_DATE>2026-08-03T00:00:00</d:NEW_DATE>
+        <d:BC_2YEAR>4.25</d:BC_2YEAR>
+        <d:BC_10YEAR>4.70</d:BC_10YEAR>
+      </m:properties></content></entry>
+    </feed>"""
+    rows = parse_treasury_yield_xml(payload)
+    assert {(row["tenor"], row["value"]) for row in rows} == {
+        ("2Y", 4.25),
+        ("10Y", 4.70),
+    }
+
+
+def test_parse_sec_payloads() -> None:
+    submissions = {
+        "filings": {
+            "recent": {
+                "accessionNumber": ["0000000000-26-000001"],
+                "filingDate": ["2026-08-01"],
+                "reportDate": ["2026-06-30"],
+                "acceptanceDateTime": ["20260801120000"],
+                "form": ["10-Q"],
+                "primaryDocument": ["form10q.htm"],
+                "primaryDocDescription": ["FORM 10-Q"],
+                "fileNumber": ["001-00001"],
+                "isXBRL": [1],
+                "isInlineXBRL": [1],
+            }
+        }
+    }
+    filing_rows = parse_sec_submissions(
+        entity_name="example", cik="0000000001", payload=submissions
+    )
+    assert filing_rows[0]["form"] == "10-Q"
+
+    facts = {
+        "facts": {
+            "us-gaap": {
+                "RevenueFromContractWithCustomerExcludingAssessedTax": {
+                    "label": "Revenue",
+                    "description": "Revenue",
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 100,
+                                "start": "2026-04-01",
+                                "end": "2026-06-30",
+                                "filed": "2026-08-01",
+                                "form": "10-Q",
+                                "fy": 2026,
+                                "fp": "Q2",
+                                "frame": "CY2026Q2",
+                                "accn": "0000000000-26-000001",
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+    }
+    fact_rows = parse_sec_companyfacts(
+        entity_name="example", cik="0000000001", payload=facts
+    )
+    assert len(fact_rows) == 1
+    assert len(fact_rows[0]["fact_id"]) == 64
+    json.dumps(fact_rows[0], default=str)


### PR DESCRIPTION
## What changed

- adds a canonical file-backed data platform under `crew/data_platform/`
- stores immutable raw responses with SHA-256, normalized Parquet, run manifests, quality results, and a DuckDB catalogue
- adds automated primary-source adapters for FRED/ALFRED, the U.S. Treasury daily par-yield curve, and SEC EDGAR submissions/company facts
- adds governed source contracts for fundnote, JPX, EDINET, LBMA, WSTS, and private collateral-contract inputs instead of fabricating unavailable data
- creates decision-ready gold views for latest credit OAS, rates, Treasury curve, SEC filings, and SEC facts
- adds `crew-data` CLI and Taskfile targets for config validation, offline tests, ingestion, status, and read-only SQL
- adds scheduled GitHub Actions snapshots while documenting that persistent Dagu/WSL storage remains canonical
- adds offline parser, lineage, storage, and quality-gate tests

## Architecture

```text
official API / governed private input
  -> immutable raw response + SHA-256
  -> partitioned Parquet bronze layer
  -> DuckDB ingestion, file, and quality catalogue
  -> deterministic gold views
  -> use-case analyses and public reports
```

## Migration policy

Legacy Yahoo-based use-case downloaders remain temporarily available. Credit and yield pipelines migrate first after canonical/legacy parity checks because ETF-price ratios are not valid substitutes for credit OAS or the Treasury term structure.

## Required runtime secrets

- `FRED_API_KEY`
- `SEC_USER_AGENT`, declared as an application name and contact address

No secret or private account data is committed.