### PR TITLE
Apply KAFKA SIGNAL to the research catalogue

### DIFF
--- a/web/static/kafka-signal.lock.json
+++ b/web/static/kafka-signal.lock.json
@@ -1,0 +1,7 @@
+{
+  "name":"KAFKA SIGNAL",
+  "release":"kafka-signal-v1.0.0",
+  "commit":"6cceef70ab3ad5d15bad972aab0b23d954fc1fd8",
+  "source":"KAFKA2306/prompt-vault/design-systems/kafka-signal",
+  "asset_hashes":{"icons/sprite.svg":"6fabaed034807143575b44f062fc9ca26293c2445ba37a3dfd07a8d9eb39b8ce","motifs/sprite.svg":"d522a16d1b7d886ef812950d47c94c9eef03efd0f530fdb08340c33e5da79885","characters/kafka-character.json":"b24e77c81d395c3959bd0756d15b06f4775f0d701a32c66e28d295b422de04e7","assets/provenance.json":"28df79f57140e881f5f7888d2865751ddc97bc486a6dca86c90e47da08dedd57"}
+}

--- a/web/static/site.js
+++ b/web/static/site.js
@@ -156,3 +156,50 @@
     });
   }
 })();
+
+(() => {
+  const release = "kafka-signal-v1.0.0";
+  document.documentElement.dataset.kafkaSignal = release;
+  const style = document.createElement("style");
+  style.textContent = `:root{--ks-canvas:#FBFAF7;--ks-surface:#FFF;--ks-subtle:#F4F2EC;--ks-ink:#243653;--ks-muted:#56657A;--ks-border:#C9D0DA;--ks-primary:#4D72A8;--ks-primary-soft:#DCE8F7;--ks-focus:#174D8B}.site-header,.hero-note,.catalogue-controls,.case-table-shell,.case-card,.process-step,.notice{border-color:var(--ks-border)!important;border-radius:.5rem!important;box-shadow:0 1px 2px rgb(36 54 83/.08)!important}.brand-mark,.category-pill,.status-pill,.view-button,.clear-button{border-radius:.25rem!important}.research-toc,.recent-reading{margin:1rem 0;padding:1rem;border:1px solid var(--ks-border);border-radius:.5rem;background:var(--ks-surface)}.research-toc h2,.recent-reading h2{margin:0 0 .5rem;font-size:1.1rem}.research-toc ol,.recent-reading ol{display:flex;gap:.5rem;flex-wrap:wrap;margin:0;padding:0;list-style:none}.research-toc a,.recent-reading a{display:inline-flex;min-height:44px;align-items:center;padding:.45rem .65rem;border:1px solid var(--ks-border);border-radius:.25rem;text-decoration:none;font-weight:800}.change-label{display:block;margin-top:.25rem;color:var(--ks-primary);font-size:.875rem;font-weight:800}:where(a,button,input,select,summary):focus-visible{outline:none!important;box-shadow:0 0 0 3px var(--ks-canvas),0 0 0 6px var(--ks-focus)!important}@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:.01ms!important;transition-duration:.01ms!important;scroll-behavior:auto!important}}`;
+  document.head.append(style);
+  const catalogue = document.querySelector("#research-catalogue");
+  const links = [...document.querySelectorAll("[data-case-row] .table-title")];
+  if (catalogue && links.length) {
+    const toc = document.createElement("nav");
+    toc.className = "research-toc";
+    toc.setAttribute("aria-label", "調査テーマ目次");
+    const items = links.map((link, index) => {
+      const row = link.closest("[data-case-row]");
+      const id = `research-${row?.dataset.caseSlug || index}`;
+      if (row) row.id = id;
+      return `<li><a href="#${id}">${link.querySelector("strong")?.textContent || link.textContent}</a></li>`;
+    }).join("");
+    toc.innerHTML = `<h2>調査テーマ目次</h2><ol>${items}</ol>`;
+    catalogue.insertBefore(toc, catalogue.querySelector(".catalogue-controls"));
+  }
+  document.querySelectorAll(".cell-secondary").forEach((node) => {
+    if (node.textContent?.trim() && node.closest("td")?.querySelector(".table-date")) {
+      node.classList.add("change-label");
+      node.textContent = `前回差分: ${node.textContent.trim()}`;
+    }
+  });
+  const key = "crewtrade-reading-history";
+  const current = location.pathname.match(/\/([^/]+)\/(\d{4}-\d{2}-\d{2})\.html$/);
+  if (current) {
+    const history = JSON.parse(localStorage.getItem(key) || "[]").filter((item) => item.href !== location.pathname);
+    history.unshift({ href: location.pathname, title: document.querySelector("h1")?.textContent?.trim() || document.title, date: current[2] });
+    localStorage.setItem(key, JSON.stringify(history.slice(0, 8)));
+  }
+  if (catalogue) {
+    const history = JSON.parse(localStorage.getItem(key) || "[]");
+    if (history.length) {
+      const panel = document.createElement("section");
+      panel.className = "recent-reading";
+      panel.innerHTML = `<h2>最近読んだレポート</h2><ol>${history.map((item) => `<li><a href="${item.href}">${item.title} · ${item.date}</a></li>`).join("")}</ol>`;
+      catalogue.insertBefore(panel, catalogue.querySelector(".catalogue-controls"));
+    }
+  }
+  const footer = document.querySelector(".site-footer .footer-inner");
+  if (footer) footer.insertAdjacentHTML("beforeend", `<span>KAFKA SIGNAL ${release} · 6cceef70</span>`);
+})();


### PR DESCRIPTION
## Summary

Applies the canonical KAFKA SIGNAL v1 identity and editorial interaction contract to the generated CrewTrade research catalogue.

## Changes

- pins `kafka-signal-v1.0.0` to prompt-vault merge `6cceef70ab3ad5d15bad972aab0b23d954fc1fd8`
- generates a compact research-topic table of contents
- labels prior-update differences explicitly
- records and exposes recent report navigation locally
- normalizes borders, radii, focus, and reduced-motion behavior
- implements the changes in `web/static`, so rebuilt Pages retain them

Closes #16.