### PR TITLE
Switch active analyses to canonical data and publish status

### DIFF
--- a/.github/workflows/data-platform.yml
+++ b/.github/workflows/data-platform.yml
@@ -4,7 +4,16 @@ on:
   pull_request:
     paths:
       - "crew/data_platform/**"
+      - "crew/credit/**"
+      - "crew/yields/**"
+      - "crew/oracle/**"
+      - "crew/legendary_investors/**"
       - "config/data_platform.yaml"
+      - "config/use_case_data_status.yaml"
+      - "config/use_cases/credit.yaml"
+      - "config/use_cases/yields.yaml"
+      - "config/use_cases/oracle.yaml"
+      - "config/use_cases/legendary_investors.yaml"
       - "tests/data_platform/**"
       - "docs/data-platform.md"
       - "pyproject.toml"
@@ -14,22 +23,32 @@ on:
     branches: [main]
     paths:
       - "crew/data_platform/**"
+      - "crew/credit/**"
+      - "crew/yields/**"
+      - "crew/oracle/**"
+      - "crew/legendary_investors/**"
       - "config/data_platform.yaml"
+      - "config/use_case_data_status.yaml"
+      - "config/use_cases/credit.yaml"
+      - "config/use_cases/yields.yaml"
+      - "config/use_cases/oracle.yaml"
+      - "config/use_cases/legendary_investors.yaml"
       - "tests/data_platform/**"
       - "pyproject.toml"
       - "Taskfile.yaml"
+      - ".github/workflows/data-platform.yml"
   workflow_dispatch:
     inputs:
       live_sync:
-        description: Fetch public primary sources and upload a snapshot artifact
+        description: Fetch primary sources and publish the sanitized status
         type: boolean
-        default: false
+        default: true
   schedule:
     - cron: "17 5 * * *"
       timezone: "Asia/Tokyo"
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: data-platform-${{ github.event_name }}-${{ github.ref }}
@@ -51,8 +70,11 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Compile platform code
-        run: uv run python -m compileall -q crew/data_platform tests/data_platform
+      - name: Compile platform and migrated analyses
+        run: |
+          uv run python -m compileall -q \
+            crew/data_platform crew/credit crew/yields crew/oracle \
+            crew/legendary_investors tests/data_platform
 
       - name: Validate source registry
         run: uv run crew-data validate-config
@@ -61,20 +83,26 @@ jobs:
         run: uv run pytest tests/data_platform -q
 
       - name: Exercise credential-free registry ingestion
-        run: uv run crew-data --root /tmp/crewtrade-platform sync --source governed_manual
+        run: |
+          uv run crew-data --root /tmp/crewtrade-platform sync --source governed_manual
+          uv run crew-data --root /tmp/crewtrade-platform export-status \
+            --output /tmp/crewtrade-public-status.json
 
   live-snapshot:
     if: >-
+      github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.live_sync)
     needs: contracts
     runs-on: ubuntu-latest
     env:
       FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
-      SEC_USER_AGENT: ${{ secrets.SEC_USER_AGENT }}
+      SEC_USER_AGENT: CrewTrade KAFKA2306 https://github.com/KAFKA2306/CrewTrade/issues
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install uv and Python
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -85,13 +113,22 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Require declared source credentials
-        run: |
-          test -n "$FRED_API_KEY" || { echo "FRED_API_KEY is required"; exit 1; }
-          test -n "$SEC_USER_AGENT" || { echo "SEC_USER_AGENT is required"; exit 1; }
-
-      - name: Fetch canonical public sources
+      - name: Fetch canonical primary sources
         run: uv run crew-data sync
+
+      - name: Generate migrated analysis reports
+        run: |
+          uv run python -m crew.credit.data_pipeline
+          uv run python -m crew.credit.analysis
+          uv run python -m crew.yields.data_pipeline
+          uv run python -m crew.yields.analysis
+          uv run python -m crew.oracle.data_pipeline
+          uv run python -m crew.oracle.analysis
+          uv run python -m crew.legendary_investors.data_pipeline
+          uv run python -m crew.legendary_investors.analysis
+
+      - name: Export sanitized Pages status
+        run: uv run crew-data export-status
 
       - name: Show ingestion state
         run: uv run crew-data status
@@ -103,3 +140,16 @@ jobs:
           path: data/platform
           retention-days: 30
           if-no-files-found: error
+
+      - name: Publish reports and status on main
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add web/generated/data-platform-status.json output/use_cases
+          if git diff --cached --quiet; then
+            echo "Published reports and status are current."
+          else
+            git commit -m "Refresh canonical data reports and status"
+            git push
+          fi

--- a/.github/workflows/uiux-static-site.yml
+++ b/.github/workflows/uiux-static-site.yml
@@ -49,13 +49,16 @@ jobs:
           uv run python -m compileall -q web
           node --check web/static/site.js
 
-      - name: Build static site and data status
-        run: |
-          uv run python web/build_static.py
-          uv run python web/build_data_status.py
+      - name: Build research catalogue
+        run: uv run python web/build_static.py
 
-      - name: Audit generated site
+      - name: Audit research catalogue
         run: uv run python web/audit_static.py
+
+      - name: Build and audit data status
+        run: |
+          uv run python web/build_data_status.py
+          uv run python web/audit_data_status.py
 
       - name: Commit generated docs on main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/uiux-static-site.yml
+++ b/.github/workflows/uiux-static-site.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "web/**"
       - "output/use_cases/**"
+      - "config/use_case_data_status.yaml"
       - "pyproject.toml"
       - "uv.lock"
       - ".github/workflows/uiux-static-site.yml"
@@ -48,8 +49,10 @@ jobs:
           uv run python -m compileall -q web
           node --check web/static/site.js
 
-      - name: Build static site
-        run: uv run python web/build_static.py
+      - name: Build static site and data status
+        run: |
+          uv run python web/build_static.py
+          uv run python web/build_data_status.py
 
       - name: Audit generated site
         run: uv run python web/audit_static.py

--- a/README.md
+++ b/README.md
@@ -1,116 +1,168 @@
-# CrewTrade — 金融調査ワークスペース
+# CrewTrade — 一次データ駆動の金融調査ワークスペース
 
-[公開ダッシュボード](https://kafka2306.github.io/CrewTrade/) · [GitHub Actions](https://github.com/KAFKA2306/CrewTrade/actions) · [データ基盤設計](docs/data-platform.md)
+[公開ダッシュボード](https://kafka2306.github.io/CrewTrade/) · [データ基盤状態](https://kafka2306.github.io/CrewTrade/data-status/) · [GitHub Actions](https://github.com/KAFKA2306/CrewTrade/actions) · [データ基盤設計](docs/data-platform.md)
 
-CrewTradeは、一次データの取得、定量計算、時系列予測、文章による解釈を分離し、分析スナップショットとして公開する研究プロジェクトです。
+CrewTradeは、一次データの取得、定量計算、評価、文章による解釈を分離し、再検証可能な分析スナップショットとして公開する研究プロジェクトです。
 
-公開画面は、レポート名の一覧ではなく、**何を検証する分析なのか**を起点に設計しています。対象・期間・計算条件・予測・解釈を同じ証拠として扱いません。
+数値が取得できない場合は推測しません。利用権、比較可能性、秘密性、機械取得経路のいずれかが不足するときは、理由付きで分析を停止し、その状態をPagesへ公開します。
+
+## 現在の運用状態
+
+10テーマを次の2群に分けています。
+
+### 正準データへ接続済み
+
+| テーマ | 正準入力 | 廃止した入力 |
+| --- | --- | --- |
+| クレジット・スプレッド | FRED / ICE BofA OAS | 債券ETF価格比 |
+| 金利・イールドスプレッド | FRED金利系列 / 米国財務省カーブ | HY実効利回り−10年国債、固定資産配分 |
+| Oracle実績・予測監査 | SEC提出履歴 / XBRL Company Facts | 静的な基準四半期・未検証予測 |
+| 著名投資家リサーチ | SEC 13F information table | 固定ティッカー配列・現在保有という表現 |
+
+### 統制された停止・一部利用
+
+| テーマ | 状態 | 再開条件 |
+| --- | --- | --- |
+| ファンド・指数比較 | 契約待ち | fundnote公式機械可読NAV |
+| 7指数ポートフォリオ | 契約待ち | JPX商品マスターと長期指数代替系列 |
+| 指数ETF比較 | 契約待ち | ISIN・正式指数・通貨・費用を含む商品契約 |
+| 貴金属スプレッド | ライセンス待ち | LBMA履歴保存・再配布権 |
+| 証券担保ローン | 非公開入力待ち | 契約版・時価・銘柄別担保掛目 |
+| 半導体サイクル | 一部利用可能 | WSTS詳細表・EDINET企業XBRL |
+
+停止中のテーマも異常ではありません。根拠が不足した数値を生成しないことを正常動作とします。
 
 ## 正準データ基盤
 
-ユースケース別のダウンロードファイルを正本とする方式から、次の共通基盤へ移行しています。
-
 ```text
-一次API・統制された非公開入力
+公式API・統制された非公開入力
   → immutable raw response + SHA-256
-  → normalized Parquet
+  → normalized Parquet bronze layer
   → DuckDB catalogue / quality / lineage
-  → use-case analysis / reports
+  → deterministic gold views
+  → use-case analysis / report / Pages
 ```
 
-自動取得対象はFRED、米財務省、SEC EDGARです。JPX、EDINET、fundnote、LBMA、WSTS、証券担保契約は、利用権・機械取得可否・秘密性を `config/data_platform.yaml` に明示し、取得不能を推測で補完しません。
-
-```bash
-uv sync
-uv run crew-data validate-config
-uv run pytest tests/data_platform -q
-
-export FRED_API_KEY=...
-export SEC_USER_AGENT='CrewTrade contact@example.com'
-uv run crew-data sync
-uv run crew-data status
-```
-
-`data/platform/` にはraw、bronze Parquet、run manifest、`catalog.duckdb` が保存されます。GitHub Actions artifactは検証用スナップショットであり、正準保存先ではありません。運用時はDagu、WSL、コンテナなどの永続ボリュームで実行します。
-
-## 公開画面
-
-- 調査テーマを検証目的で整理
-- テーマ、問い、対象、期間、警告を横断検索
-- 最新スナップショット、評価状態、レポート数を表示
-- 日付別レポートから前提や結論の変化を追跡
-- 数値、モデル予測、LLM解釈を別の証拠として表示
-- 掲載値がリアルタイムではないこと、投資助言ではないことを明示
-
-## 調査テーマ
-
-| 公開スラッグ | 表示名 | 主な検証軸 |
-| --- | --- | --- |
-| `credit` | クレジット・スプレッド | 信用リスクへの追加補償は悪化余地に見合うか |
-| `imura` | ファンド・指数比較 | 条件とリスクをそろえても超過収益が残るか |
-| `index_7_portfolio` | 7指数ポートフォリオ | 分散が実際の下落局面で機能するか |
-| `index_etf_comparison` | 指数ETF比較 | 同じ指数名でも投資結果を分ける条件は何か |
-| `legendary_investors` | 著名投資家リサーチ | 公開情報から再現可能な判断原則を抽出できるか |
-| `oracle` | Oracle実績・予測監査 | 受注残が売上とキャッシュへ転換するか |
-| `precious_metals_spread` | 貴金属スプレッド | 価格差が平均回帰か構造変化か |
-| `securities_collateral_loan` | 証券担保ローン | どの下落率から意思決定の自由が失われるか |
-| `semiconductors` | 半導体サイクル | 利益成長が数量・価格・能力のどこから生じるか |
-| `yield_spread` | 金利・イールドスプレッド | 金利差がどの期待とリスクプレミアムを反映するか |
-
-## ディレクトリ構造
+`data/platform/` が実行環境内の正準保存先です。
 
 ```text
-config/data_platform.yaml   一次データ源・利用権・更新契約
-config/use_cases/           ユースケース設定
-crew/data_platform/         取得・raw保存・Parquet・DuckDB・品質検査
-                               sources/  FRED / Treasury / SEC / governed manual
-                               cli.py    crew-data CLI
-                               storage.py immutable lake + catalogue
-                               quality.py common quality gates
-data/platform/              正準データ（Git管理外）
-output/use_cases/           公開分析結果の正本
-web/                        GitHub Pages生成器・静的監査
-docs/                       生成された公開サイトと設計文書
-tests/data_platform/        ネットワーク非依存の契約試験
+data/platform/
+├── raw/               取得した原文レスポンス
+├── bronze/            正規化Parquet
+├── manifests/         実行単位の来歴
+└── catalog.duckdb     実行・ファイル・品質・gold view
 ```
+
+GitHub Actionsのartifactは30日保持の検証スナップショットです。長期の正準履歴はDagu、WSL、コンテナなどの永続ボリュームで保持します。
+
+## 一次データ源
+
+- FRED APIを利用できる場合は`realtime_start`・`realtime_end`を含む改訂ビンテージを保存
+- APIキーがない場合もFRED公式CSVを取得時点スナップショットとして保存
+- 米国財務省の公式XMLから日次パー・イールド・カーブを取得
+- SEC EDGARから提出履歴、Company Facts、13F information table XMLを取得
+- JPX、EDINET、fundnote、LBMA、WSTS、非公開担保契約は`config/data_platform.yaml`で利用権と停止条件を管理
+
+## 自動運用
+
+`main`への基盤変更時、手動実行時、毎日05:17 JSTに次を実行します。
+
+1. 正準一次データを取得
+2. raw・SHA-256・Parquet・DuckDBへ保存
+3. 共通品質検査を実行
+4. 接続済み4テーマのレポートを生成
+5. 公開可能な状態だけを`web/generated/data-platform-status.json`へ出力
+6. GitHub Pagesを再生成・監査・公開
+
+必要な秘密情報は任意の`FRED_API_KEY`だけです。SECのUser-Agentは公開リポジトリの連絡先をworkflowで宣言します。FRED APIキーがなくても公式CSVスナップショットで稼働します。
 
 ## 実行
 
 ```bash
+uv sync
+
 task data:validate
 task data:test
-task data:sync:registry   # 外部認証不要
-task data:sync:public     # FRED_API_KEY / SEC_USER_AGENT 必須
+task data:sync          # 全正準ソース
 task data:status
+task data:export-status
 
-task process:all          # 移行期間中の既存パイプラインと分析
-task serve                # ローカルWeb画面
+task process:all        # 正準取得 → 4分析 → Pages状態
 ```
 
-静的サイトのみを生成・監査する場合:
+個別実行:
+
+```bash
+task fetch:credit && task analyze:credit
+task fetch:yield && task analyze:yield
+task fetch:oracle && task analyze:oracle
+task fetch:legendary_investors && task analyze:legendary_investors
+```
+
+正準カタログをSQLで監査できます。
+
+```bash
+uv run crew-data query "select * from gold_credit_oas_latest"
+uv run crew-data query "select * from gold_treasury_curve_latest"
+uv run crew-data query "select * from gold_sec_13f_holdings_latest"
+```
+
+静的サイトの生成と監査:
 
 ```bash
 uv run python web/build_static.py
 uv run python web/audit_static.py
+uv run python web/build_data_status.py
+uv run python web/audit_data_status.py
 ```
 
-## 分析品質の確認項目
+## 主要ディレクトリ
 
-- データ対象期間、取得日時、公開日時、改訂ビンテージを残す
-- 原文レスポンスとSHA-256を保存する
-- 通貨、単位、配当、分割、市場休業日、ライセンスを明示する
-- 比較指数と計算条件をそろえる
-- インサンプルとアウト・オブ・サンプルを分離する
-- 手数料、税、スリッページを含まない結果を実績と呼ばない
-- 予測入力期間、予測期間、評価指標を保存する
-- LLMによる文章と定量計算結果を区別する
-- 取得失敗、欠損、利用権未確認を推測で補完しない
+```text
+config/data_platform.yaml          一次データ源・利用権・更新契約
+config/use_case_data_status.yaml   10テーマの正準移行・停止状態
+config/use_cases/                  分析条件
+crew/data_platform/                取得・raw・Parquet・DuckDB・品質
+crew/credit/                       正準OAS分析
+crew/yields/                       正準金利・カーブ分析
+crew/oracle/                       SEC XBRL分析
+crew/legendary_investors/          SEC 13F差分分析
+data/platform/                     正準データ。Git管理外
+output/use_cases/                  公開レポートの正本
+web/                               GitHub Pages生成・監査
+web/generated/                     公開可能な基盤状態
+web/templates/data_status.html     データ状態ページ
+docs/                              生成済みPages
+tests/data_platform/               ネットワーク非依存の契約試験
+```
+
+## 品質契約
+
+- 対象期間、観測日、取得日時、公開日時、改訂ビンテージを保存
+- 原文レスポンスとSHA-256を保存
+- 主キーNULL、重複、非有限値、空データを拒否
+- 通貨、単位、配当、分割、市場休業日、利用権を明示
+- 異なる時点・定義・単位を無条件に結合しない
+- 会社実績、会社予想、独自導出値、モデル予測を分離
+- インサンプルとアウト・オブ・サンプルを分離
+- 取得失敗や利用権未確認を推測で補完しない
+- 非公開契約・口座状態をPagesへ出力しない
+
+## 完了判定
+
+Pages上のデータ基盤状態を`OK`とする条件は次です。
+
+- 正準接続済み4テーマの必要データセットが存在する
+- 最新バッチの品質検査が成功している
+- 残る6テーマが理由付きの統制状態にある
+- 公開状態に秘密情報が含まれない
+- 調査カタログとデータ状態の静的監査が成功する
 
 ## 注意
 
-- 掲載値は各レポート作成日時点のスナップショットです
+- 掲載値は各レポート生成日時点のスナップショットです
+- 13Fは四半期末時点の限定的な開示で、現在保有を示しません
 - 過去の成績は将来の収益を保証しません
-- 予測値は確定的な将来価格ではありません
 - 本プロジェクトは投資助言、売買推奨、運用実績の保証ではありません
 
 **最終構造監査:** 2026-08-04

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -2,10 +2,11 @@ version: "3"
 
 tasks:
   process:all:
-    desc: Run all data pipelines then all analysis
+    desc: Sync canonical sources, run active analyses, and export Pages status
     cmds:
       - task: fetch:all
       - task: analyze:all
+      - task: data:export-status
 
   data:validate:
     desc: Validate canonical data platform configuration
@@ -36,36 +37,26 @@ tasks:
     desc: Show canonical ingestion runs and datasets
     cmd: uv run crew-data status
 
+  data:export-status:
+    desc: Export sanitized canonical status for GitHub Pages
+    cmd: uv run crew-data export-status
+
   fetch:all:
-    desc: Run all legacy data fetchers during migration to the canonical platform
+    desc: Export all canonical-active use cases from DuckDB
     cmds:
-      - task: fetch:imura
-      - task: fetch:oracle
+      - task: data:sync
       - task: fetch:credit
-      - task: fetch:etf
-      - task: fetch:loan
-      - task: fetch:metals
-      - task: fetch:portfolio
       - task: fetch:yield
-      - task: fetch:semiconductors
+      - task: fetch:oracle
       - task: fetch:legendary_investors
 
   analyze:all:
-    desc: Run all analysis
+    desc: Run canonical-active analyses only; governed blocks remain stopped
     aliases: [run]
     cmds:
-      - task: sync
-      - task: lint
-      - task: format
-      - task: analyze:imura
-      - task: analyze:oracle
       - task: analyze:credit
-      - task: analyze:etf
-      - task: analyze:loan
-      - task: analyze:metals
-      - task: analyze:portfolio
       - task: analyze:yield
-      - task: analyze:semiconductors
+      - task: analyze:oracle
       - task: analyze:legendary_investors
 
   lint:
@@ -74,11 +65,6 @@ tasks:
     cmd: uv run ruff format .
   sync:
     cmd: uv sync
-
-  fetch:imura:
-    cmd: uv run python -m crew.imura.data_pipeline
-  analyze:imura:
-    cmd: uv run python -m crew.imura.analysis
 
   fetch:oracle:
     cmd: uv run python -m crew.oracle.data_pipeline
@@ -90,40 +76,31 @@ tasks:
   analyze:credit:
     cmd: uv run python -m crew.credit.analysis
 
-  fetch:etf:
-    cmd: uv run python -m crew.etf.data_pipeline
-  analyze:etf:
-    cmd: uv run python -m crew.etf.analysis
-
-  fetch:loan:
-    cmd: uv run python -m crew.loan.data_pipeline
-  analyze:loan:
-    cmd: uv run python -m crew.loan.analysis
-
-  fetch:metals:
-    cmd: uv run python -m crew.metals.data_pipeline
-  analyze:metals:
-    cmd: uv run python -m crew.metals.analysis
-
-  fetch:portfolio:
-    cmd: uv run python -m crew.portfolio.data_pipeline
-  analyze:portfolio:
-    cmd: uv run python -m crew.portfolio.analysis
-
   fetch:yield:
     cmd: uv run python -m crew.yields.data_pipeline
   analyze:yield:
     cmd: uv run python -m crew.yields.analysis
 
-  fetch:semiconductors:
-    cmd: uv run python -m crew.semiconductors.data_pipeline
-  analyze:semiconductors:
-    cmd: uv run python -m crew.use_case_runner semiconductors --config config/use_cases/semiconductors.yaml
-
   fetch:legendary_investors:
     cmd: uv run python -m crew.legendary_investors.data_pipeline
   analyze:legendary_investors:
-    cmd: uv run python -m crew.use_case_runner legendary_investors --config config/use_cases/legendary_investors.yaml
+    cmd: uv run python -m crew.legendary_investors.analysis
+
+  blocked:imura:
+    desc: Governed stop — official machine-readable NAV contract is missing
+    cmd: echo "imura is intentionally stopped; see data-status"
+  blocked:etf:
+    desc: Governed stop — JPX/EDINET product contract is missing
+    cmd: echo "ETF comparisons are intentionally stopped; see data-status"
+  blocked:metals:
+    desc: Governed stop — LBMA historical data license is missing
+    cmd: echo "metals is intentionally stopped; see data-status"
+  blocked:loan:
+    desc: Governed stop — private contract/account input is required
+    cmd: echo "collateral loan live state requires private input; see data-status"
+  blocked:semiconductors:
+    desc: Governed partial — public WSTS releases only
+    cmd: echo "semiconductors is partially available; see data-status"
 
   serve:
     desc: Run the HTMX web dashboard

--- a/config/data_platform.yaml
+++ b/config/data_platform.yaml
@@ -46,9 +46,13 @@ sources:
       soros_fund_management:
         cik: "1029160"
         companyfacts: false
+        thirteen_f_information_table: true
+        history_limit: 8
       duquesne_family_office:
         cik: "1536411"
         companyfacts: false
+        thirteen_f_information_table: true
+        history_limit: 8
 
   governed_manual:
     adapter: governed_manual

--- a/config/use_case_data_status.yaml
+++ b/config/use_case_data_status.yaml
@@ -1,0 +1,67 @@
+schema_version: 1
+allowed_controlled_states:
+  - canonical_active
+  - governed_blocked
+  - governed_partial
+  - private_input_required
+use_cases:
+  credit:
+    title: クレジット・スプレッド
+    state: canonical_active
+    required_datasets: [credit_oas]
+    owner_source: FRED / ICE BofA
+    note: ETF価格比を廃止し、公式OASへ移行済み。
+  yield_spread:
+    title: 金利・イールドスプレッド
+    state: canonical_active
+    required_datasets: [rates_macro, treasury_par_yield_curve]
+    owner_source: FRED / U.S. Treasury
+    note: 国債カーブ・実質金利・期待インフレを分離。
+  oracle:
+    title: Oracle実績・予測監査
+    state: canonical_active
+    required_datasets: [sec_filings, sec_company_facts]
+    owner_source: SEC EDGAR
+    note: 静的実績値を廃止し、提出履歴とXBRL factsへ移行。
+  legendary_investors:
+    title: 著名投資家リサーチ
+    state: canonical_active
+    required_datasets: [sec_filings, sec_13f_holdings]
+    owner_source: SEC EDGAR 13F
+    note: 固定銘柄配列を廃止し、information tableへ移行。
+  imura:
+    title: ファンド・指数比較
+    state: governed_blocked
+    required_contracts: [fundnote_kaihou]
+    owner_source: fundnote株式会社
+    note: 公式機械可読NAV契約が整うまで数値更新を停止。
+  index_7_portfolio:
+    title: 7指数ポートフォリオ
+    state: governed_blocked
+    required_contracts: [jpx_etf_master]
+    owner_source: JPX / 各運用会社
+    note: 正式商品マスターと指数代替系列の整備待ち。
+  index_etf_comparison:
+    title: 指数ETF比較
+    state: governed_blocked
+    required_contracts: [jpx_etf_master, edinet_api_v2]
+    owner_source: JPX / EDINET
+    note: ISIN・指数・通貨・費用を揃えた商品契約待ち。
+  precious_metals_spread:
+    title: 貴金属スプレッド
+    state: governed_blocked
+    required_contracts: [lbma_benchmarks]
+    owner_source: LBMA
+    note: 履歴保存・再配布ライセンスが整うまで日次シグナル停止。
+  securities_collateral_loan:
+    title: 証券担保ローン
+    state: private_input_required
+    required_contracts: [broker_collateral_contract]
+    owner_source: 非公開契約・口座状態
+    note: 公開Pagesへ契約・口座値を出さず、入力状態だけ表示。
+  semiconductors:
+    title: 半導体サイクル
+    state: governed_partial
+    required_contracts: [wsts_market_data, edinet_api_v2]
+    owner_source: WSTS / EDINET / 企業開示
+    note: 公開リリースは利用可能、会員表と企業XBRLは追加契約待ち。

--- a/config/use_cases/credit.yaml
+++ b/config/use_cases/credit.yaml
@@ -1,14 +1,11 @@
 name: credit_spread
+dataset: credit_oas
 period: 5y
-rolling_window: 30
-minimum_periods: 10
+rolling_window: 60
+minimum_periods: 20
 z_score_threshold: 1.5
-pairs:
-  HYG_vs_IEF:
-    junk_ticker: HYG
-    treasury_ticker: IEF
-    description: US high yield vs 7-10Y Treasury
-  JNK_vs_TLT:
-    junk_ticker: JNK
-    treasury_ticker: TLT
-    description: US high yield vs 20Y Treasury
+bp_alert_threshold: 15.0
+series_labels:
+  - us_corporate_oas
+  - us_bbb_oas
+  - us_high_yield_oas

--- a/config/use_cases/legendary_investors.yaml
+++ b/config/use_cases/legendary_investors.yaml
@@ -1,17 +1,11 @@
-period: "1y"
-benchmark: "SPY"
-soros_holdings:
-  - "AMZN"
-  - "SW"
-  - "GOOGL"
-  - "RSP"
-  - "TKO"
-druckenmiller_holdings:
-  - "NTRA"
-  - "INSM"
-  - "TEVA"
-  - "TSM"
-  - "WWD"
-  - "CPNG"
-  - "MELI"
-  - "DOCU"
+name: legendary_investors
+forms: [13F-HR, 13F-HR/A]
+managers:
+  soros_fund_management:
+    display_name: Soros Fund Management LLC
+    cik: "1029160"
+  duquesne_family_office:
+    display_name: Duquesne Family Office LLC
+    cik: "1536411"
+minimum_history_quarters: 2
+top_holdings_limit: 20

--- a/config/use_cases/oracle.yaml
+++ b/config/use_cases/oracle.yaml
@@ -1,33 +1,20 @@
-base_quarter:
-  period: "FY2026 Q2"
-  revenue_B: 14.1
-  operating_income_B: 4.8
-  capex_last_4q_B: 7.2
-  current_capex_intensity: 0.55
-  rpo_B: 99.0
-  cloud_revenue_growth_yoy_pct: 34.0
-  software_revenue_growth_yoy_pct: 0.0
-  software_seasonality_factors: [0.95, 1.0, 0.98, 1.05]
-  cloud_cannibalization_ratio: 0.1
-
-projections:
-  quarters_to_project: 8
-  scenarios:
-    bull:
-      cloud_growth_decay_rate: 0.99
-      software_growth_rate: 1.0
-      operating_margin_improvement: 2.0
-      capex_intensity_target: 0.40
-      rpo_growth_yoy: 0.20
-    bear:
-      cloud_growth_decay_rate: 0.90
-      software_growth_rate: -2.0
-      operating_margin_improvement: 0.0
-      capex_intensity_target: 0.60
-      rpo_growth_yoy: 0.10
-    base:
-      cloud_growth_decay_rate: 0.95
-      software_growth_rate: -0.5
-      operating_margin_improvement: 0.5
-      capex_intensity_target: 0.50
-      rpo_growth_yoy: 0.15
+name: oracle
+entity_name: oracle
+forms: [10-K, 10-Q, 8-K]
+concepts:
+  revenue:
+    - RevenueFromContractWithCustomerExcludingAssessedTax
+    - Revenues
+  operating_income:
+    - OperatingIncomeLoss
+  operating_cash_flow:
+    - NetCashProvidedByUsedInOperatingActivities
+  capital_expenditure:
+    - PaymentsToAcquirePropertyPlantAndEquipment
+    - PaymentsToAcquireProductiveAssets
+  free_cash_flow:
+    - FreeCashFlow
+  remaining_performance_obligation:
+    - RemainingPerformanceObligation
+    - RemainingPerformanceObligations
+allow_model_projection: false

--- a/config/use_cases/yields.yaml
+++ b/config/use_cases/yields.yaml
@@ -1,4 +1,4 @@
-name: yield_spread
+name: yields
 rates_dataset: rates_macro
 curve_dataset: treasury_par_yield_curve
 period: 5y

--- a/config/use_cases/yields.yaml
+++ b/config/use_cases/yields.yaml
@@ -1,49 +1,17 @@
 name: yield_spread
+rates_dataset: rates_macro
+curve_dataset: treasury_par_yield_curve
 period: 5y
 rolling_window: 60
 minimum_periods: 20
 z_score_threshold: 1.5
-bp_alert_threshold: 0.0
-allocation:
-  upper_z: 1.0
-  lower_z: -1.0
-  optimization:
-    enabled: true
-    lookback: 1y
-    sample_size: 15000
-    min_weight: 0.0
-    max_weight: 0.6
-    risk_free_rate: 0.02
-  tightening:
-    label: Risk-On
-    weights:
-      SPY: 0.6
-      QQQ: 0.2
-      HYG: 0.2
-  neutral:
-    label: Neutral
-    weights:
-      SPY: 0.5
-      IEF: 0.3
-      HYG: 0.2
-  widening:
-    label: Defensive
-    weights:
-      IEF: 0.5
-      TLT: 0.3
-      BIL: 0.2
-pairs:
-  us_high_yield_vs_us10y:
-    description: US High Yield minus 10Y Treasury yield spread
-    junk:
-      source: fred
-      identifier: BAMLH0A0HYM2EY
-      scaling: 1.0
-      field: value
-      description: ICE BofA US High Yield Index Effective Yield (%)
-    treasury:
-      source: fred
-      identifier: DGS10
-      scaling: 1.0
-      field: value
-      description: US 10Y Treasury Constant Maturity Rate (%)
+bp_alert_threshold: 25.0
+curve_spreads:
+  us_2s10s:
+    short_label: us_2y
+    long_label: us_10y
+    description: US 10Y minus 2Y constant maturity rate
+  us_10s30s:
+    short_label: us_10y
+    long_label: us_30y
+    description: US 30Y minus 10Y constant maturity rate

--- a/crew/credit/analysis.py
+++ b/crew/credit/analysis.py
@@ -1,198 +1,166 @@
 from __future__ import annotations
+
+from pathlib import Path
 from typing import Dict, List
+from zoneinfo import ZoneInfo
+import datetime
+
 import numpy as np
 import pandas as pd
+import yaml
+
 from crew.credit.config import CreditSpreadConfig
+
+
 class CreditSpreadAnalyzer:
+    """Measure official ICE BofA option-adjusted spreads, not ETF price ratios."""
+
     def __init__(self, config: CreditSpreadConfig) -> None:
         self.config = config
-    def evaluate(
-        self, data_payload: Dict[str, pd.DataFrame]
-    ) -> Dict[str, pd.DataFrame]:
-        price_frame = data_payload["prices"]
-        metrics = self._compute_pair_metrics(price_frame)
-        edges = self._detect_edges(metrics)
+        self.raw_data_dir: Path | None = None
+
+    def evaluate(self, data_payload: Dict[str, object]) -> Dict[str, pd.DataFrame]:
+        oas = self._load_frame(data_payload.get("oas"), "oas.parquet")
+        provenance = self._load_frame(
+            data_payload.get("provenance"), "provenance.parquet", required=False
+        )
+        if "Date" in oas.columns:
+            oas["Date"] = pd.to_datetime(oas["Date"])
+            oas = oas.set_index("Date")
+        oas.index = pd.to_datetime(oas.index)
+        oas = oas.sort_index()
+
+        missing = sorted(set(self.config.series_labels).difference(oas.columns))
+        if missing:
+            raise ValueError(f"Canonical credit series are missing: {missing}")
+        oas = oas[self.config.series_labels].apply(pd.to_numeric, errors="coerce")
+
+        metrics = self._compute_metrics(oas)
+        signals = self._detect_signals(metrics)
         snapshot = self._build_snapshot(metrics)
         return {
-            "prices": price_frame,
+            "oas": oas,
             "metrics": metrics,
-            "edges": edges,
+            "signals": signals,
             "snapshot": snapshot,
+            "provenance": provenance,
         }
-    def _compute_pair_metrics(self, price_frame: pd.DataFrame) -> pd.DataFrame:
-        metrics_store: Dict[str, pd.DataFrame] = {}
-        returns = price_frame.pct_change()
-        for label, pair in self.config.pairs.items():
-            junk = price_frame[pair.junk_ticker]
-            treasury = price_frame[pair.treasury_ticker]
-            ratio = junk / treasury
-            log_ratio = np.log(ratio)
-            rolling_mean = log_ratio.rolling(
-                window=self.config.rolling_window,
+
+    def _load_frame(
+        self, value: object, filename: str, *, required: bool = True
+    ) -> pd.DataFrame:
+        if isinstance(value, pd.DataFrame):
+            return value.copy()
+        if isinstance(value, (str, Path)) and Path(value).is_file():
+            return pd.read_parquet(value)
+        if self.raw_data_dir is not None:
+            path = self.raw_data_dir / filename
+            if path.is_file():
+                return pd.read_parquet(path)
+        if required:
+            raise FileNotFoundError(
+                f"Canonical export {filename} is missing. Run `task fetch:credit`."
+            )
+        return pd.DataFrame()
+
+    def _compute_metrics(self, oas: pd.DataFrame) -> pd.DataFrame:
+        store: Dict[str, pd.DataFrame] = {}
+        for label in self.config.series_labels:
+            level = oas[label].dropna()
+            mean = level.rolling(
+                self.config.rolling_window,
                 min_periods=self.config.minimum_periods,
             ).mean()
-            rolling_std = log_ratio.rolling(
-                window=self.config.rolling_window,
+            std = level.rolling(
+                self.config.rolling_window,
                 min_periods=self.config.minimum_periods,
-            ).std()
-            rolling_std = rolling_std.replace(0, np.nan)
-            z_score = (log_ratio - rolling_mean) / rolling_std
-            return_gap = returns[pair.junk_ticker] - returns[pair.treasury_ticker]
-            metrics_store[label] = pd.DataFrame(
+            ).std().replace(0, np.nan)
+            store[label] = pd.DataFrame(
                 {
-                    "ratio": ratio,
-                    "log_ratio": log_ratio,
-                    "return_gap": return_gap,
-                    "rolling_mean": rolling_mean,
-                    "rolling_std": rolling_std,
-                    "z_score": z_score,
+                    "level_pct": level,
+                    "change_1d_bp": level.diff() * 100.0,
+                    "change_20d_bp": level.diff(20) * 100.0,
+                    "rolling_mean_pct": mean,
+                    "rolling_std_pct": std,
+                    "z_score": (level - mean) / std,
                 }
             )
-        metrics_frame = pd.concat(metrics_store, axis=1)
-        return metrics_frame
-    def _detect_edges(self, metrics_frame: pd.DataFrame) -> pd.DataFrame:
-        records: List[Dict[str, object]] = []
-        for label, pair in self.config.pairs.items():
-            pair_frame = metrics_frame[label].dropna(subset=["z_score"])
-            if pair_frame.empty:
-                continue
-            mask = pair_frame["z_score"].abs() >= self.config.z_score_threshold
-            filtered = pair_frame.loc[mask]
-            if filtered.empty:
-                continue
-            for timestamp, row in filtered.iterrows():
-                direction = (
-                    "spread_widening" if row["z_score"] > 0 else "spread_tightening"
-                )
+        return pd.concat(store, axis=1).sort_index()
+
+    def _detect_signals(self, metrics: pd.DataFrame) -> pd.DataFrame:
+        records: List[dict[str, object]] = []
+        for label in self.config.series_labels:
+            frame = metrics[label].dropna(subset=["z_score"])
+            mask = frame["z_score"].abs() >= self.config.z_score_threshold
+            if self.config.bp_alert_threshold > 0:
+                mask &= frame["change_20d_bp"].abs() >= self.config.bp_alert_threshold
+            for timestamp, row in frame.loc[mask].iterrows():
                 records.append(
                     {
                         "date": timestamp,
-                        "pair": label,
-                        "junk": pair.junk_ticker,
-                        "treasury": pair.treasury_ticker,
-                        "z_score": row["z_score"],
-                        "ratio": row["ratio"],
-                        "return_gap": row["return_gap"],
-                        "signal": direction,
-                        "description": pair.description or "",
+                        "series": label,
+                        "level_pct": float(row["level_pct"]),
+                        "change_20d_bp": float(row["change_20d_bp"]),
+                        "z_score": float(row["z_score"]),
+                        "direction": "widening" if row["z_score"] > 0 else "tightening",
                     }
                 )
-        if not records:
-            return pd.DataFrame(
-                columns=[
-                    "date",
-                    "pair",
-                    "junk",
-                    "treasury",
-                    "z_score",
-                    "ratio",
-                    "return_gap",
-                    "signal",
-                    "description",
-                ]
-            )
-        edges_frame = pd.DataFrame.from_records(records)
-        edges_frame = edges_frame.sort_values("date")
-        return edges_frame
-    def _build_snapshot(self, metrics_frame: pd.DataFrame) -> pd.DataFrame:
-        snapshot_rows: List[Dict[str, object]] = []
-        for label, pair in self.config.pairs.items():
-            pair_frame = metrics_frame[label].dropna(subset=["z_score"])
-            if pair_frame.empty:
+        columns = [
+            "date",
+            "series",
+            "level_pct",
+            "change_20d_bp",
+            "z_score",
+            "direction",
+        ]
+        return pd.DataFrame.from_records(records, columns=columns).sort_values(
+            "date", ignore_index=True
+        ) if records else pd.DataFrame(columns=columns)
+
+    def _build_snapshot(self, metrics: pd.DataFrame) -> pd.DataFrame:
+        rows: List[dict[str, object]] = []
+        for label in self.config.series_labels:
+            frame = metrics[label].dropna(subset=["level_pct"])
+            if frame.empty:
                 continue
-            last_row = pair_frame.iloc[-1]
-            snapshot_rows.append(
+            latest = frame.iloc[-1]
+            rows.append(
                 {
-                    "pair": label,
-                    "junk": pair.junk_ticker,
-                    "treasury": pair.treasury_ticker,
-                    "latest_date": pair_frame.index[-1],
-                    "z_score": last_row["z_score"],
-                    "ratio": last_row["ratio"],
-                    "return_gap": last_row["return_gap"],
+                    "series": label,
+                    "latest_date": frame.index[-1],
+                    "level_pct": float(latest["level_pct"]),
+                    "change_1d_bp": _optional_float(latest["change_1d_bp"]),
+                    "change_20d_bp": _optional_float(latest["change_20d_bp"]),
+                    "z_score": _optional_float(latest["z_score"]),
                 }
             )
-        if not snapshot_rows:
-            return pd.DataFrame(
-                columns=[
-                    "pair",
-                    "junk",
-                    "treasury",
-                    "latest_date",
-                    "z_score",
-                    "ratio",
-                    "return_gap",
-                ]
-            )
-        return pd.DataFrame(snapshot_rows)
-if __name__ == "__main__":
-    import yaml
-    from pathlib import Path
-    from crew.credit.config import CreditSpreadConfig
+        return pd.DataFrame(rows)
+
+
+def _optional_float(value: object) -> float | None:
+    return None if pd.isna(value) else float(value)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+CONFIG_FILE = PROJECT_ROOT / "config" / "use_cases" / "credit.yaml"
+DATA_DIR = PROJECT_ROOT / "data" / "credit_spread"
+
+
+def main() -> None:
     from crew.credit.reporting import CreditSpreadReporter
-    from crew.utils.kronos_utils import get_kronos_forecast
-    PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-    CONFIG_FILE = PROJECT_ROOT / "config" / "use_cases" / "credit.yaml"
-    DATA_DIR = PROJECT_ROOT / "data" / "credit_spread"
-    import datetime
-    today = datetime.date.today().strftime("%Y%m%d")
-    REPORT_DIR = PROJECT_ROOT / "output" / "use_cases" / "credit" / today
-    with open(CONFIG_FILE, "r", encoding="utf-8") as f:
-        config_data = yaml.safe_load(f)
-    config = CreditSpreadConfig(**config_data)
-    prices_path = DATA_DIR / "prices.parquet"
-    if not prices_path.exists():
-        print(f"Warning: {prices_path} not found. Trying CSV fallback.")
-        prices_path = DATA_DIR / "prices.csv"
-    if str(prices_path).endswith(".parquet") and prices_path.exists():
-        prices = pd.read_parquet(prices_path)
-    elif prices_path.exists():
-        prices = pd.read_csv(prices_path, parse_dates=["Date"])
-    else:
-        print("Error: No price data found.")
-        exit(1)
-    data_payload = {"prices": prices.set_index("Date")}
+
+    config = CreditSpreadConfig(
+        **yaml.safe_load(CONFIG_FILE.read_text(encoding="utf-8"))
+    )
     analyzer = CreditSpreadAnalyzer(config)
-    analysis_results = analyzer.evaluate(data_payload)
-    forecasts = {}
-    for ticker in config.tickers:
-        ticker_path = DATA_DIR / f"{ticker}.parquet"
-        if ticker_path.exists():
-            try:
-                df = pd.read_parquet(ticker_path)
-                df.columns = [str(c).lower() for c in df.columns]
-                if "close" in df.columns and "open" not in df.columns:
-                    df["open"] = df["close"]
-                    df["high"] = df["close"]
-                    df["low"] = df["close"]
-                    df["volume"] = 0.0
-                if "date" in df.columns:
-                    df["Date"] = pd.to_datetime(df["date"])
-                elif df.index.name and df.index.name.lower() == "date":
-                    df = df.reset_index()
-                    df["Date"] = pd.to_datetime(
-                        df["Date"] if "Date" in df.columns else df["date"]
-                    )
-                if "Date" in df.columns:
-                    df = df.sort_values("Date").reset_index(drop=True)
-                    x_timestamp = df["Date"]
-                    pred_len = 30
-                    last_date = df["Date"].iloc[-1]
-                    future_dates = [
-                        last_date + pd.Timedelta(days=i + 1) for i in range(pred_len)
-                    ]
-                    y_timestamp = pd.Series(future_dates)
-                    pred_df = get_kronos_forecast(
-                        df=df,
-                        x_timestamp=x_timestamp,
-                        y_timestamp=y_timestamp,
-                        pred_len=pred_len,
-                    )
-                    forecasts[ticker] = pred_df.to_dict(orient="records")
-            except Exception as e:
-                print(f"Kronos forecast failed for {ticker}: {e}")
-                forecasts[ticker] = {"error": str(e)}
-    analysis_results["forecasts"] = forecasts
-    reporter = CreditSpreadReporter(config, DATA_DIR / "processed", REPORT_DIR)
-    reporter.persist(analysis_results)
-    print(f"Report produced in {REPORT_DIR}")
+    analyzer.raw_data_dir = DATA_DIR
+    results = analyzer.evaluate({})
+    report_date = datetime.datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y%m%d")
+    report_dir = PROJECT_ROOT / "output" / "use_cases" / "credit" / report_date
+    reporter = CreditSpreadReporter(config, DATA_DIR / "processed", report_dir)
+    stored = reporter.persist(results)
+    print(f"Canonical credit report: {stored['report']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crew/credit/config.py
+++ b/crew/credit/config.py
@@ -1,40 +1,41 @@
 from __future__ import annotations
-from typing import Dict, List, Set
-from pydantic import BaseModel, Field
+
+from typing import List
+
+from pydantic import Field, validator
+
 from crew.base import UseCaseConfig
-class CreditSpreadPair(BaseModel):
-    junk_ticker: str
-    treasury_ticker: str
-    description: str | None = None
+
+
 class CreditSpreadConfig(UseCaseConfig):
+    dataset: str = Field(default="credit_oas")
     period: str = Field(default="5y")
-    rolling_window: int = Field(default=30)
-    minimum_periods: int = Field(default=10)
-    z_score_threshold: float = Field(default=1.5)
-    pairs: Dict[str, CreditSpreadPair] = Field(
-        default_factory=lambda: {
-            "HYG_vs_IEF": CreditSpreadPair(
-                junk_ticker="HYG",
-                treasury_ticker="IEF",
-                description="US high yield vs 7-10Y Treasury",
-            ),
-            "JNK_vs_TLT": CreditSpreadPair(
-                junk_ticker="JNK",
-                treasury_ticker="TLT",
-                description="US high yield vs 20Y Treasury",
-            ),
-        }
+    rolling_window: int = Field(default=60, ge=2)
+    minimum_periods: int = Field(default=20, ge=2)
+    z_score_threshold: float = Field(default=1.5, gt=0)
+    bp_alert_threshold: float = Field(default=15.0, ge=0)
+    series_labels: List[str] = Field(
+        default_factory=lambda: [
+            "us_corporate_oas",
+            "us_bbb_oas",
+            "us_high_yield_oas",
+        ]
     )
-    @property
-    def tickers(self) -> List[str]:
-        seen: Set[str] = set()
-        ordered: List[str] = []
-        for pair in self.pairs.values():
-            if pair.junk_ticker not in seen:
-                ordered.append(pair.junk_ticker)
-                seen.add(pair.junk_ticker)
-            if pair.treasury_ticker not in seen:
-                ordered.append(pair.treasury_ticker)
-                seen.add(pair.treasury_ticker)
-        return ordered
+
+    @validator("period")
+    def _validate_period(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if len(normalized) < 2 or normalized[-1] not in {"y", "m", "d"}:
+            raise ValueError("period must end with y, m, or d")
+        int(normalized[:-1])
+        return normalized
+
+    @validator("minimum_periods")
+    def _validate_minimum_periods(cls, value: int, values: dict) -> int:
+        rolling_window = values.get("rolling_window")
+        if rolling_window is not None and value > rolling_window:
+            raise ValueError("minimum_periods must not exceed rolling_window")
+        return value
+
+
 DEFAULT_CONFIG = CreditSpreadConfig(name="credit_spread")

--- a/crew/credit/data_pipeline.py
+++ b/crew/credit/data_pipeline.py
@@ -1,38 +1,69 @@
 from __future__ import annotations
+
 from pathlib import Path
 from typing import Dict
+
 import pandas as pd
+
 from crew.app import BaseDataPipeline
-from crew.clients import FixedIncomeDataClient, get_price_series
 from crew.credit.config import CreditSpreadConfig
+from crew.data_platform.consumer import latest_vintage_series, pivot_latest_vintage
+
+
 class CreditSpreadDataPipeline(BaseDataPipeline):
+    """Export point-in-time FRED OAS data from the canonical DuckDB catalogue."""
+
     def __init__(self, raw_data_dir: Path, config: CreditSpreadConfig) -> None:
         super().__init__(raw_data_dir, config)
-        self.client = FixedIncomeDataClient(raw_data_dir)
+
     def fetch_data_internal(self, targets: Dict[str, str], days: int) -> Dict[str, str]:
-        frames = self.client.get_frames(self.config.tickers, self.config.period)
-        prices = self._combine_close(frames)
-        saved_files = {}
-        name = "prices"
-        df = prices.reset_index()
-        self._save(name, df)
-        saved_files[name] = str(self.raw_data_dir / f"{name}.parquet")
-        return saved_files
-    def _combine_close(self, frames: Dict[str, pd.DataFrame]) -> pd.DataFrame:
-        series_list = []
-        for ticker, frame in frames.items():
-            price_series = get_price_series(frame)
-            series_list.append(price_series.rename(ticker))
-        combined = pd.concat(series_list, axis=1)
-        combined = combined.sort_index()
-        return combined.ffill()
+        history = pivot_latest_vintage(self.config.dataset)
+        history = self._slice_period(history, self.config.period)
+        missing = sorted(set(self.config.series_labels).difference(history.columns))
+        if missing:
+            raise ValueError(f"Canonical credit series are missing: {missing}")
+        history = history[self.config.series_labels]
+
+        provenance = latest_vintage_series(self.config.dataset)
+        provenance = provenance[
+            provenance["label"].isin(self.config.series_labels)
+        ].copy()
+        if not history.empty:
+            provenance = provenance[
+                provenance["observation_date"] >= history.index.min()
+            ]
+
+        self._save("oas", history.reset_index())
+        self._save("provenance", provenance)
+        return {
+            "oas": str(self.raw_data_dir / "oas.parquet"),
+            "provenance": str(self.raw_data_dir / "provenance.parquet"),
+        }
+
+    @staticmethod
+    def _slice_period(frame: pd.DataFrame, period: str) -> pd.DataFrame:
+        if frame.empty:
+            return frame
+        value = int(period[:-1])
+        unit = period[-1]
+        end = frame.index.max()
+        if unit == "y":
+            start = end - pd.DateOffset(years=value)
+        elif unit == "m":
+            start = end - pd.DateOffset(months=value)
+        else:
+            start = end - pd.Timedelta(days=value)
+        return frame.loc[start:end]
+
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-CONFIG_FILE = (
-    PROJECT_ROOT / "config" / "use_cases" / "credit.yaml"
-)
+CONFIG_FILE = PROJECT_ROOT / "config" / "use_cases" / "credit.yaml"
+
+
 def main() -> None:
     from crew.app import GenericUseCase
     from crew.credit.analysis import CreditSpreadAnalyzer
+
     use_case = GenericUseCase(
         config_path=CONFIG_FILE,
         pipeline_class=CreditSpreadDataPipeline,
@@ -41,6 +72,8 @@ def main() -> None:
     )
     saved_files = use_case.fetch_data()
     for name, path in saved_files.items():
-        print(f"Saved {name}: {path}")
+        print(f"Saved canonical {name}: {path}")
+
+
 if __name__ == "__main__":
     main()

--- a/crew/credit/insights.py
+++ b/crew/credit/insights.py
@@ -1,106 +1,57 @@
 from __future__ import annotations
-from typing import Dict, List
+
+from typing import Dict
+
 import pandas as pd
-def build_insight_markdown(analysis_payload: Dict[str, pd.DataFrame]) -> str:
-    prices = analysis_payload["prices"]
-    metrics = analysis_payload["metrics"]
-    snapshot = analysis_payload["snapshot"]
-    edges = analysis_payload["edges"]
-    date_start = prices.index.min()
-    date_end = prices.index.max()
-    lines: List[str] = []
-    lines.append("
-    lines.append("")
-    lines.append("
-    lines.append(f"- Price range: {date_start.date()} → {date_end.date()}")
-    lines.append(f"- Pairs analysed: {len(snapshot)}")
-    lines.append("")
+
+
+_LABELS = {
+    "us_corporate_oas": "米国社債OAS",
+    "us_bbb_oas": "米国BBB社債OAS",
+    "us_high_yield_oas": "米国ハイイールドOAS",
+}
+
+
+def build_insight_markdown(
+    analysis_payload: Dict[str, pd.DataFrame],
+) -> str:
+    """Return a compact optional summary for canonical OAS output."""
+
+    snapshot = analysis_payload.get("snapshot", pd.DataFrame())
+    signals = analysis_payload.get("signals", pd.DataFrame())
+    lines = ["## 正準OASスナップショット", ""]
     if snapshot.empty:
-        lines.append("No sufficient data to compute spreads.")
+        lines.append("正準OASスナップショットはありません。")
         return "\n".join(lines)
-    snapshot_table = snapshot.copy()
-    snapshot_table["latest_date"] = snapshot_table["latest_date"].dt.date
-    snapshot_table["z_score"] = snapshot_table["z_score"].round(2)
-    snapshot_table["ratio"] = snapshot_table["ratio"].round(4)
-    snapshot_table["return_gap"] = (snapshot_table["return_gap"] * 100).round(2)
-    lines.append("
-    lines.append(
-        _format_table(
-            snapshot_table,
-            ["pair", "latest_date", "z_score", "ratio", "return_gap"],
-            ["Pair", "Date", "Z", "Ratio", "Return Gap %"],
-        )
+
+    table = snapshot.copy().sort_values("series")
+    lines.extend(
+        [
+            "| 系列 | 観測日 | 水準 | 20日変化 | z値 |",
+            "| --- | --- | ---: | ---: | ---: |",
+        ]
     )
-    lines.append("")
-    if edges.empty:
-        lines.append("
-        lines.append("No |z|-score breaches within the sampled horizon.")
-        return "\n".join(lines)
-    lines.append("
-    lines.append(f"- Total signals: {len(edges)}")
-    lines.append("")
-    counts = edges.groupby(["pair", "signal"]).size().reset_index(name="signals")
-    lines.append(
-        _format_table(
-            counts, ["pair", "signal", "signals"], ["Pair", "Signal", "Count"]
-        )
-    )
-    lines.append("")
-    recent_start = edges["date"].max() - pd.Timedelta(days=90)
-    recent_edges = edges[edges["date"] >= recent_start]
-    lines.append("
-    if recent_edges.empty:
-        lines.append("No breaches recorded in the last 90 days.")
-    else:
-        recent_counts = recent_edges.groupby("pair").size().reset_index(name="signals")
-        recent_median = (
-            recent_edges.groupby("pair")["z_score"]
-            .median()
-            .reset_index(name="median_z")
-        )
-        merged = pd.merge(recent_counts, recent_median, on="pair", how="left")
-        merged["median_z"] = merged["median_z"].round(2)
+    for _, row in table.iterrows():
         lines.append(
-            _format_table(
-                merged,
-                ["pair", "signals", "median_z"],
-                ["Pair", "Signals", "Median |Z|"],
+            "| {label} | {date} | {level:.2f}% | {change} | {z} |".format(
+                label=_LABELS.get(str(row["series"]), str(row["series"])),
+                date=pd.Timestamp(row["latest_date"]).date(),
+                level=float(row["level_pct"]),
+                change=_format_bp(row.get("change_20d_bp")),
+                z=_format_number(row.get("z_score")),
             )
         )
-    lines.append("")
-    vol_stats = (
-        metrics.stack(level=0)["z_score"]
-        .dropna()
-        .groupby(level=1)
-        .agg(["mean", "std", "max"])
-        .reset_index()
-        .rename(columns={"level_1": "pair", "index": "pair"})
-    )
-    if not vol_stats.empty:
-        vol_stats["mean"] = vol_stats["mean"].round(2)
-        vol_stats["std"] = vol_stats["std"].round(2)
-        vol_stats["max"] = vol_stats["max"].round(2)
-        lines.append("
-        lines.append(
-            _format_table(
-                vol_stats,
-                ["pair", "mean", "std", "max"],
-                ["Pair", "Mean", "Std", "Max"],
-            )
-        )
-        lines.append("")
+    lines.extend(["", f"閾値超過イベント: {len(signals)}件"])
     return "\n".join(lines)
-def _format_table(df: pd.DataFrame, columns: List[str], headers: List[str]) -> str:
-    table_lines: List[str] = []
-    table_lines.append("| " + " | ".join(headers) + " |")
-    table_lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
-    for _, row in df[columns].iterrows():
-        formatted: List[str] = []
-        for col in columns:
-            value = row[col]
-            if isinstance(value, float):
-                formatted.append(f"{value:.2f}")
-            else:
-                formatted.append(str(value))
-        table_lines.append("| " + " | ".join(formatted) + " |")
-    return "\n".join(table_lines)
+
+
+def _format_bp(value: object) -> str:
+    if value is None or pd.isna(value):
+        return "—"
+    return f"{float(value):+.1f}bp"
+
+
+def _format_number(value: object) -> str:
+    if value is None or pd.isna(value):
+        return "—"
+    return f"{float(value):+.2f}"

--- a/crew/credit/reporting.py
+++ b/crew/credit/reporting.py
@@ -1,9 +1,22 @@
 from __future__ import annotations
+
+from datetime import datetime
 from pathlib import Path
 from typing import Dict
+from zoneinfo import ZoneInfo
+
 import pandas as pd
+
 from crew.credit.config import CreditSpreadConfig
-from crew.credit.insights import build_insight_markdown
+
+
+_LABELS = {
+    "us_corporate_oas": "米国社債OAS",
+    "us_bbb_oas": "米国BBB社債OAS",
+    "us_high_yield_oas": "米国ハイイールドOAS",
+}
+
+
 class CreditSpreadReporter:
     def __init__(
         self, config: CreditSpreadConfig, processed_dir: Path, report_dir: Path
@@ -13,82 +26,138 @@ class CreditSpreadReporter:
         self.report_dir = report_dir
         self.processed_dir.mkdir(parents=True, exist_ok=True)
         self.report_dir.mkdir(parents=True, exist_ok=True)
-    def persist(self, analysis_payload: Dict[str, pd.DataFrame]) -> Dict[str, Path]:
-        prices = analysis_payload["prices"]
-        metrics = analysis_payload["metrics"]
-        edges = analysis_payload["edges"]
-        snapshot = analysis_payload["snapshot"]
-        stored_paths: Dict[str, Path] = {}
-        prices_path = self.processed_dir / "prices.parquet"
-        prices.to_parquet(prices_path)
-        stored_paths["prices"] = prices_path
-        metrics_path = self.processed_dir / "metrics.parquet"
-        metrics.to_parquet(metrics_path)
-        stored_paths["metrics"] = metrics_path
-        snapshot_path = self.processed_dir / "snapshot.parquet"
-        snapshot.to_parquet(snapshot_path)
-        stored_paths["snapshot"] = snapshot_path
-        edges_path = self.processed_dir / "edges.parquet"
-        edges.to_parquet(edges_path)
-        stored_paths["edges"] = edges_path
-        report_path = self.report_dir / "spread_signals.md"
-        report_content = self._format_report(edges, snapshot)
-        if "forecasts" in analysis_payload:
-            report_content += "\n
-            for asset, forecast_data in analysis_payload["forecasts"].items():
-                if isinstance(forecast_data, dict) and "error" in forecast_data:
-                    report_content += f"
-                    continue
-                if not forecast_data:
-                    continue
-                last_forecast = forecast_data[-1]
-                report_content += f"
-                report_content += (
-                    f"Prediction End: {last_forecast.get('date', 'N/A')}\n"
-                )
-                report_content += (
-                    f"Predicted Close: {last_forecast.get('close', 'N/A'):.2f}\n"
-                )
-        report_path.write_text(report_content)
-        stored_paths["report"] = report_path
-        insight_path = self.report_dir / "spread_insights.md"
-        insight_markdown = build_insight_markdown(analysis_payload)
-        insight_path.write_text(insight_markdown)
-        stored_paths["insights"] = insight_path
-        return stored_paths
-    def _format_report(self, edges: pd.DataFrame, snapshot: pd.DataFrame) -> str:
-        lines = ["
+
+    def persist(self, payload: Dict[str, pd.DataFrame]) -> Dict[str, Path]:
+        stored: Dict[str, Path] = {}
+        for key in ("oas", "metrics", "signals", "snapshot", "provenance"):
+            value = payload.get(key)
+            if isinstance(value, pd.DataFrame):
+                path = self.processed_dir / f"{key}.parquet"
+                value.to_parquet(path)
+                stored[key] = path
+
+        report_path = self.report_dir / "report.md"
+        report_path.write_text(self._build_report(payload), encoding="utf-8")
+        stored["report"] = report_path
+        return stored
+
+    def _build_report(self, payload: Dict[str, pd.DataFrame]) -> str:
+        snapshot = payload["snapshot"]
+        signals = payload["signals"]
+        provenance = payload.get("provenance", pd.DataFrame())
         if snapshot.empty:
-            lines.append("十分なデータがなく、スナップショットを生成できませんでした。")
-            return "\n".join(lines)
-        lines.append("
-        lines.append("| Pair | Junk | Treasury | Date | Z | Ratio | Return Gap % |")
-        lines.append("| --- | --- | --- | --- | --- | --- | --- |")
-        for _, row in snapshot.sort_values(
-            "z_score", key=lambda s: s.abs(), ascending=False
-        ).iterrows():
-            date_str = row["latest_date"].date()
-            z = row["z_score"]
-            ratio = row["ratio"]
-            return_gap = row["return_gap"] * 100
+            raise ValueError("Cannot publish a credit report without a snapshot")
+
+        checked_on = datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y-%m-%d")
+        latest_date = pd.to_datetime(snapshot["latest_date"]).max().strftime("%Y-%m-%d")
+        complete = len(snapshot) == len(self.config.series_labels)
+        freshest_gap = (
+            pd.Timestamp(checked_on) - pd.Timestamp(latest_date)
+        ).days
+        data_score = 5 if freshest_gap <= 3 else 4 if freshest_gap <= 7 else 2
+        total_score = data_score + 5 + (5 if complete else 2) + 4 + 3
+
+        lines = [
+            "# クレジット・スプレッド定量監査",
+            "",
+            f"更新基準日: {checked_on}",
+            "",
+            "## 結論",
+            "",
+            "信用評価をETF価格比から切り離し、FREDで公表されるICE BofAオプション調整後スプレッドへ完全移行しました。最新値、20営業日変化、ローリングz値を同じビンテージから計算します。",
+            "",
+            "## データ",
+            "",
+            f"正準データ基盤の最新観測日は **{latest_date}** です。単位はパーセント、変化量はベーシスポイントです。",
+            "",
+            "| 系列 | 最新値 | 1日変化 | 20日変化 | z値 |",
+            "| --- | ---: | ---: | ---: | ---: |",
+        ]
+        for _, row in snapshot.sort_values("series").iterrows():
             lines.append(
-                f"| {row['pair']} | {row['junk']} | {row['treasury']} | {date_str} | {z:.2f} | {ratio:.4f} | {return_gap:.2f} |"
+                "| {label} | {level:.2f}% | {d1} | {d20} | {z} |".format(
+                    label=_LABELS.get(str(row["series"]), str(row["series"])),
+                    level=float(row["level_pct"]),
+                    d1=_format_bp(row["change_1d_bp"]),
+                    d20=_format_bp(row["change_20d_bp"]),
+                    z=_format_number(row["z_score"]),
+                )
             )
-        lines.append("")
-        if edges.empty:
-            lines.append("
-            lines.append("しきい値を超えるスプレッドシグナルは検出されていません。")
-            return "\n".join(lines)
-        lines.append("
-        lines.append("| Date | Pair | Signal | Z | Ratio | Return Gap % |")
-        lines.append("| --- | --- | --- | --- | --- | --- |")
-        for _, row in edges.sort_values("date").iterrows():
-            date_str = row["date"].strftime("%Y-%m-%d")
-            z = row["z_score"]
-            ratio = row["ratio"]
-            return_gap = row["return_gap"] * 100
-            lines.append(
-                f"| {date_str} | {row['pair']} | {row['signal']} | {z:.2f} | {ratio:.4f} | {return_gap:.2f} |"
+
+        lines.extend(
+            [
+                "",
+                "各行はrawレスポンスのSHA-256、取得時刻、FRED URL、リアルタイム期間を保持するParquetから生成されています。",
+                "",
+                "## 定量分析",
+                "",
+                f"ローリング窓は{self.config.rolling_window}観測、最小観測数は{self.config.minimum_periods}です。`z=(最新値-移動平均)/移動標準偏差`で計算します。",
+                "",
+            ]
+        )
+        if signals.empty:
+            lines.append("現在、z値と20日変化の両方が設定閾値を超える新規シグナルはありません。")
+        else:
+            latest_signals = signals.sort_values("date").tail(10)
+            lines.extend(
+                [
+                    "直近の閾値超過:",
+                    "",
+                    "| 日付 | 系列 | 方向 | 水準 | 20日変化 | z値 |",
+                    "| --- | --- | --- | ---: | ---: | ---: |",
+                ]
             )
+            for _, row in latest_signals.iterrows():
+                lines.append(
+                    f"| {pd.Timestamp(row['date']).date()} | {_LABELS.get(str(row['series']), row['series'])} | {row['direction']} | {float(row['level_pct']):.2f}% | {_format_bp(row['change_20d_bp'])} | {float(row['z_score']):.2f} |"
+                )
+
+        lines.extend(
+            [
+                "",
+                "## 評価",
+                "",
+                "| 評価軸 | 点数 | 根拠 |",
+                "| --- | ---: | --- |",
+                f"| データ鮮度 | {data_score}/5 | 最新観測から確認日まで{freshest_gap}日 |",
+                "| 定義の妥当性 | 5/5 | 信用OASの公式系列を直接使用 |",
+                f"| 系列完全性 | {5 if complete else 2}/5 | {len(snapshot)}/{len(self.config.series_labels)}系列 |",
+                "| ビンテージ管理 | 4/5 | FRED realtime期間と取得時刻を保存 |",
+                "| 意思決定可能性 | 3/5 | 警戒には使用可能、単独売買根拠にはしない |",
+                f"| **合計** | **{total_score}/25** | **正準OAS経路へ移行済み** |",
+                "",
+                "## 限界と反証条件",
+                "",
+                "- OASだけではデフォルト率、格下げ率、発行市場流動性を表しません。",
+                "- 最新値が更新されない場合は正常値として前方補完せず、鮮度低下として表示します。",
+                "- FRED系列ID、単位、定義が変更された場合は同一系列として継続しません。",
+                "- ETF価格差やモデル予測を信用スプレッド実績へ混入させません。",
+                "",
+                "## 一次情報",
+                "",
+            ]
+        )
+        urls = []
+        if isinstance(provenance, pd.DataFrame) and "_source_url" in provenance.columns:
+            urls = sorted(set(str(value) for value in provenance["_source_url"].dropna()))
+        if not urls:
+            urls = [
+                "https://fred.stlouisfed.org/series/BAMLC0A0CM",
+                "https://fred.stlouisfed.org/series/BAMLC0A4CBBB",
+                "https://fred.stlouisfed.org/series/BAMLH0A0HYM2",
+            ]
+        lines.extend(f"- {url}" for url in urls)
         lines.append("")
         return "\n".join(lines)
+
+
+def _format_bp(value: object) -> str:
+    if value is None or pd.isna(value):
+        return "—"
+    return f"{float(value):+.1f}bp"
+
+
+def _format_number(value: object) -> str:
+    if value is None or pd.isna(value):
+        return "—"
+    return f"{float(value):+.2f}"

--- a/crew/data_platform/cli.py
+++ b/crew/data_platform/cli.py
@@ -5,10 +5,13 @@ from pathlib import Path
 
 import duckdb
 
+from crew.data_platform.public_status import export_public_status
 from crew.data_platform.registry import load_config, sync
 
 
 DEFAULT_CONFIG = Path("config/data_platform.yaml")
+DEFAULT_MIGRATION_CONFIG = Path("config/use_case_data_status.yaml")
+DEFAULT_PUBLIC_STATUS = Path("web/generated/data-platform-status.json")
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -32,6 +35,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     query_parser = subparsers.add_parser("query", help="Run a read-only DuckDB query")
     query_parser.add_argument("sql")
+
+    export_parser = subparsers.add_parser(
+        "export-status", help="Write a sanitized status snapshot for GitHub Pages"
+    )
+    export_parser.add_argument(
+        "--migration-config", type=Path, default=DEFAULT_MIGRATION_CONFIG
+    )
+    export_parser.add_argument("--output", type=Path, default=DEFAULT_PUBLIC_STATUS)
 
     subparsers.add_parser("validate-config", help="Validate configuration only")
     return parser
@@ -60,6 +71,20 @@ def main(argv: list[str] | None = None) -> int:
                 f"sha256={batch.raw_sha256[:16]} parquet={batch.parquet_path}"
             )
         print(f"Manifest: {manifest}")
+        return 0
+
+    if args.command == "export-status":
+        payload = export_public_status(
+            output_path=args.output,
+            platform_config_path=args.config,
+            migration_config_path=args.migration_config,
+            root=args.root,
+        )
+        print(
+            f"Public status: {payload['overall_status']} -> {args.output} "
+            f"({payload['summary']['canonical_ok']} canonical OK, "
+            f"{payload['summary']['controlled_blocks']} controlled)"
+        )
         return 0
 
     catalog = root / "catalog.duckdb"

--- a/crew/data_platform/consumer.py
+++ b/crew/data_platform/consumer.py
@@ -28,7 +28,12 @@ def resolve_catalog(root: Path | None = None) -> Path:
     return catalog
 
 
-def query_frame(sql: str, parameters: Iterable[object] | None = None, *, root: Path | None = None) -> pd.DataFrame:
+def query_frame(
+    sql: str,
+    parameters: Iterable[object] | None = None,
+    *,
+    root: Path | None = None,
+) -> pd.DataFrame:
     catalog = resolve_catalog(root)
     try:
         with duckdb.connect(str(catalog), read_only=True) as connection:
@@ -77,8 +82,14 @@ def pivot_latest_vintage(dataset: str, *, root: Path | None = None) -> pd.DataFr
     return pivot
 
 
-def treasury_curve(*, latest_only: bool = False, root: Path | None = None) -> pd.DataFrame:
-    view = "gold_treasury_curve_latest" if latest_only else "bronze_treasury_par_yield_curve"
+def treasury_curve(
+    *, latest_only: bool = False, root: Path | None = None
+) -> pd.DataFrame:
+    view = (
+        "gold_treasury_curve_latest"
+        if latest_only
+        else "bronze_treasury_par_yield_curve"
+    )
     frame = query_frame(
         f"""
         SELECT observation_date, tenor, value, unit, curve_type,
@@ -126,7 +137,12 @@ def sec_filings(
     )
     if frame.empty:
         raise CanonicalDataUnavailable("No matching SEC filings are available")
-    for column in ("filing_date", "report_date", "acceptance_datetime", "_retrieved_at"):
+    for column in (
+        "filing_date",
+        "report_date",
+        "acceptance_datetime",
+        "_retrieved_at",
+    ):
         frame[column] = pd.to_datetime(frame[column])
     return frame
 
@@ -159,5 +175,45 @@ def sec_company_facts(
     if frame.empty:
         raise CanonicalDataUnavailable(f"No SEC company facts for {entity_name}")
     for column in ("start_date", "end_date", "filed_date", "_retrieved_at"):
+        frame[column] = pd.to_datetime(frame[column])
+    return frame
+
+
+def sec_13f_holdings(
+    *,
+    entity_names: Iterable[str] | None = None,
+    latest_only: bool = False,
+    root: Path | None = None,
+) -> pd.DataFrame:
+    view = (
+        "gold_sec_13f_holdings_latest"
+        if latest_only
+        else "bronze_sec_13f_holdings"
+    )
+    names = list(entity_names or [])
+    where = ""
+    parameters: list[object] = []
+    if names:
+        where = "WHERE entity_name IN (" + ",".join("?" for _ in names) + ")"
+        parameters.extend(names)
+    frame = query_frame(
+        f"""
+        SELECT holding_id, entity_name, entity_cik, accession_number,
+               report_date, filing_date, issuer, title_of_class, cusip,
+               figi, reported_value, reported_value_unit,
+               shares_or_principal, shares_or_principal_type, put_call,
+               investment_discretion, other_manager, voting_sole,
+               voting_shared, voting_none, source_document_url,
+               _retrieved_at, _source_url, _raw_sha256
+        FROM {view}
+        {where}
+        ORDER BY entity_name, report_date DESC, reported_value DESC NULLS LAST
+        """,
+        parameters,
+        root=root,
+    )
+    if frame.empty:
+        raise CanonicalDataUnavailable("No matching SEC 13F holdings are available")
+    for column in ("report_date", "filing_date", "_retrieved_at"):
         frame[column] = pd.to_datetime(frame[column])
     return frame

--- a/crew/data_platform/consumer.py
+++ b/crew/data_platform/consumer.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+import duckdb
+import pandas as pd
+
+
+class CanonicalDataUnavailable(RuntimeError):
+    """Raised when a canonical dataset has not been materialized yet."""
+
+
+def resolve_root(root: Path | None = None) -> Path:
+    if root is not None:
+        return Path(root)
+    configured = os.environ.get("CREWTRADE_DATA_ROOT", "data/platform").strip()
+    return Path(configured or "data/platform")
+
+
+def resolve_catalog(root: Path | None = None) -> Path:
+    catalog = resolve_root(root) / "catalog.duckdb"
+    if not catalog.is_file():
+        raise CanonicalDataUnavailable(
+            f"Canonical catalogue is missing: {catalog}. Run `crew-data sync` first."
+        )
+    return catalog
+
+
+def query_frame(sql: str, parameters: Iterable[object] | None = None, *, root: Path | None = None) -> pd.DataFrame:
+    catalog = resolve_catalog(root)
+    try:
+        with duckdb.connect(str(catalog), read_only=True) as connection:
+            return connection.execute(sql, list(parameters or [])).fetchdf()
+    except duckdb.CatalogException as error:
+        raise CanonicalDataUnavailable(str(error)) from error
+
+
+def latest_vintage_series(dataset: str, *, root: Path | None = None) -> pd.DataFrame:
+    if dataset not in {"credit_oas", "rates_macro"}:
+        raise ValueError(f"Unsupported series dataset: {dataset}")
+    frame = query_frame(
+        f"""
+        WITH ranked AS (
+            SELECT *,
+                   row_number() OVER (
+                       PARTITION BY series_id, observation_date
+                       ORDER BY realtime_start DESC, _retrieved_at DESC
+                   ) AS vintage_rank
+            FROM bronze_{dataset}
+        )
+        SELECT series_id, label, observation_date, value, realtime_start,
+               realtime_end, units, title, _retrieved_at, _source_url,
+               _raw_sha256
+        FROM ranked
+        WHERE vintage_rank = 1
+        ORDER BY observation_date, label
+        """,
+        root=root,
+    )
+    if frame.empty:
+        raise CanonicalDataUnavailable(f"Canonical dataset is empty: {dataset}")
+    frame["observation_date"] = pd.to_datetime(frame["observation_date"])
+    return frame
+
+
+def pivot_latest_vintage(dataset: str, *, root: Path | None = None) -> pd.DataFrame:
+    long_frame = latest_vintage_series(dataset, root=root)
+    pivot = long_frame.pivot_table(
+        index="observation_date",
+        columns="label",
+        values="value",
+        aggfunc="last",
+    ).sort_index()
+    pivot.index.name = "Date"
+    return pivot
+
+
+def treasury_curve(*, latest_only: bool = False, root: Path | None = None) -> pd.DataFrame:
+    view = "gold_treasury_curve_latest" if latest_only else "bronze_treasury_par_yield_curve"
+    frame = query_frame(
+        f"""
+        SELECT observation_date, tenor, value, unit, curve_type,
+               _retrieved_at, _source_url, _raw_sha256
+        FROM {view}
+        ORDER BY observation_date, tenor
+        """,
+        root=root,
+    )
+    if frame.empty:
+        raise CanonicalDataUnavailable("Canonical Treasury curve is empty")
+    frame["observation_date"] = pd.to_datetime(frame["observation_date"])
+    return frame
+
+
+def sec_filings(
+    *,
+    entity_names: Iterable[str] | None = None,
+    forms: Iterable[str] | None = None,
+    root: Path | None = None,
+) -> pd.DataFrame:
+    clauses: list[str] = []
+    parameters: list[object] = []
+    names = list(entity_names or [])
+    form_values = list(forms or [])
+    if names:
+        clauses.append("entity_name IN (" + ",".join("?" for _ in names) + ")")
+        parameters.extend(names)
+    if form_values:
+        clauses.append("form IN (" + ",".join("?" for _ in form_values) + ")")
+        parameters.extend(form_values)
+    where = "WHERE " + " AND ".join(clauses) if clauses else ""
+    frame = query_frame(
+        f"""
+        SELECT entity_name, entity_cik, accession_number, filing_date,
+               report_date, acceptance_datetime, form, primary_document,
+               primary_doc_description, _retrieved_at, _source_url,
+               _raw_sha256
+        FROM bronze_sec_filings
+        {where}
+        ORDER BY filing_date DESC, acceptance_datetime DESC
+        """,
+        parameters,
+        root=root,
+    )
+    if frame.empty:
+        raise CanonicalDataUnavailable("No matching SEC filings are available")
+    for column in ("filing_date", "report_date", "acceptance_datetime", "_retrieved_at"):
+        frame[column] = pd.to_datetime(frame[column])
+    return frame
+
+
+def sec_company_facts(
+    *,
+    entity_name: str,
+    concepts: Iterable[str] | None = None,
+    root: Path | None = None,
+) -> pd.DataFrame:
+    clauses = ["entity_name = ?"]
+    parameters: list[object] = [entity_name]
+    concept_values = list(concepts or [])
+    if concept_values:
+        clauses.append("concept IN (" + ",".join("?" for _ in concept_values) + ")")
+        parameters.extend(concept_values)
+    frame = query_frame(
+        f"""
+        SELECT fact_id, entity_name, entity_cik, taxonomy, concept, label,
+               unit, value, start_date, end_date, filed_date, form,
+               fiscal_year, fiscal_period, frame, accession_number,
+               _retrieved_at, _source_url, _raw_sha256
+        FROM bronze_sec_company_facts
+        WHERE {' AND '.join(clauses)}
+        ORDER BY end_date DESC NULLS LAST, filed_date DESC NULLS LAST
+        """,
+        parameters,
+        root=root,
+    )
+    if frame.empty:
+        raise CanonicalDataUnavailable(f"No SEC company facts for {entity_name}")
+    for column in ("start_date", "end_date", "filed_date", "_retrieved_at"):
+        frame[column] = pd.to_datetime(frame[column])
+    return frame

--- a/crew/data_platform/gold.py
+++ b/crew/data_platform/gold.py
@@ -91,3 +91,44 @@ def refresh_gold_views(catalog_path: Path) -> None:
                 WHERE _rank = 1
                 """
             )
+
+        if "sec_13f_holdings" in datasets:
+            connection.execute(
+                """
+                CREATE OR REPLACE VIEW gold_sec_13f_holdings_latest AS
+                WITH deduplicated AS (
+                    SELECT * EXCLUDE (_holding_rank)
+                    FROM (
+                        SELECT *,
+                               row_number() OVER (
+                                   PARTITION BY holding_id
+                                   ORDER BY _retrieved_at DESC
+                               ) AS _holding_rank
+                        FROM bronze_sec_13f_holdings
+                    )
+                    WHERE _holding_rank = 1
+                ),
+                filing_candidates AS (
+                    SELECT entity_cik, accession_number, report_date, filing_date,
+                           max(_retrieved_at) AS latest_retrieved_at
+                    FROM deduplicated
+                    GROUP BY entity_cik, accession_number, report_date, filing_date
+                ),
+                ranked_filings AS (
+                    SELECT *,
+                           row_number() OVER (
+                               PARTITION BY entity_cik
+                               ORDER BY report_date DESC,
+                                        filing_date DESC,
+                                        latest_retrieved_at DESC
+                           ) AS filing_rank
+                    FROM filing_candidates
+                )
+                SELECT holdings.*
+                FROM deduplicated AS holdings
+                INNER JOIN ranked_filings AS filings
+                    ON holdings.entity_cik = filings.entity_cik
+                   AND holdings.accession_number = filings.accession_number
+                WHERE filings.filing_rank = 1
+                """
+            )

--- a/crew/data_platform/public_status.py
+++ b/crew/data_platform/public_status.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 import duckdb
 import yaml
@@ -50,6 +51,12 @@ def build_public_status(
         missing_datasets = [
             dataset for dataset in required_datasets if dataset not in dataset_status
         ]
+        failed_datasets = [
+            dataset
+            for dataset in required_datasets
+            if dataset in dataset_status
+            and dataset_status[dataset]["quality_status"] != "ok"
+        ]
         contract_rows = []
         for contract_name in required_contracts:
             contract = dict(governed_contracts.get(contract_name, {}))
@@ -66,8 +73,12 @@ def build_public_status(
             )
 
         if declared_state == "canonical_active":
-            runtime_state = "ok" if not missing_datasets else "awaiting_snapshot"
-            active_missing |= bool(missing_datasets)
+            runtime_state = (
+                "ok"
+                if not missing_datasets and not failed_datasets
+                else "awaiting_snapshot"
+            )
+            active_missing |= bool(missing_datasets or failed_datasets)
         else:
             runtime_state = declared_state
         use_case_rows.append(
@@ -81,6 +92,7 @@ def build_public_status(
                 "note": definition.get("note"),
                 "required_datasets": required_datasets,
                 "missing_datasets": missing_datasets,
+                "failed_datasets": failed_datasets,
                 "required_contracts": contract_rows,
             }
         )
@@ -94,7 +106,9 @@ def build_public_status(
         "overall_status": overall_status,
         "catalog_present": catalog_path.is_file(),
         "latest_run": latest_run,
-        "datasets": sorted(dataset_status.values(), key=lambda row: row["dataset"]),
+        "datasets": sorted(
+            dataset_status.values(), key=lambda row: row["dataset"]
+        ),
         "use_cases": use_case_rows,
         "summary": {
             "use_case_count": len(use_case_rows),
@@ -146,18 +160,30 @@ def _catalog_status(
     with duckdb.connect(str(catalog_path), read_only=True) as connection:
         dataset_rows = connection.execute(
             """
-            SELECT dataset, source, row_count, raw_sha256, source_url,
-                   retrieved_at, metadata_json, run_id
-            FROM (
+            WITH latest_files AS (
                 SELECT *,
                        row_number() OVER (
                            PARTITION BY dataset
                            ORDER BY retrieved_at DESC, run_id DESC
                        ) AS dataset_rank
                 FROM dataset_files
+            ),
+            quality AS (
+                SELECT dataset, run_id,
+                       count(*) FILTER (WHERE passed = false) AS failed_checks
+                FROM quality_results
+                GROUP BY dataset, run_id
             )
-            WHERE dataset_rank = 1
-            ORDER BY dataset
+            SELECT files.dataset, files.source, files.row_count,
+                   files.raw_sha256, files.source_url, files.retrieved_at,
+                   files.metadata_json, files.run_id,
+                   coalesce(quality.failed_checks, 0) AS failed_checks
+            FROM latest_files AS files
+            LEFT JOIN quality
+              ON files.dataset = quality.dataset
+             AND files.run_id = quality.run_id
+            WHERE files.dataset_rank = 1
+            ORDER BY files.dataset
             """
         ).fetchall()
         latest_run_row = connection.execute(
@@ -168,21 +194,10 @@ def _catalog_status(
             LIMIT 1
             """
         ).fetchone()
-        failed_checks = {
-            row[0]: int(row[1])
-            for row in connection.execute(
-                """
-                SELECT dataset, count(*)
-                FROM quality_results
-                WHERE passed = false
-                GROUP BY dataset
-                """
-            ).fetchall()
-        }
 
     status: dict[str, dict[str, Any]] = {}
     for row in dataset_rows:
-        metadata = json.loads(row[6]) if row[6] else {}
+        metadata = _metadata_mapping(row[6])
         status[str(row[0])] = {
             "dataset": str(row[0]),
             "source": str(row[1]),
@@ -191,7 +206,7 @@ def _catalog_status(
             "source_url": str(row[4]),
             "retrieved_at": _iso(row[5]),
             "run_id": str(row[7]),
-            "quality_status": "ok" if failed_checks.get(str(row[0]), 0) == 0 else "failed",
+            "quality_status": "ok" if int(row[8]) == 0 else "failed",
             "retrieval_mode": metadata.get("retrieval_mode"),
             "point_in_time_vintage": metadata.get("point_in_time_vintage"),
         }
@@ -205,6 +220,17 @@ def _catalog_status(
             "error": latest_run_row[4],
         }
     return status, latest_run
+
+
+def _metadata_mapping(value: object) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if value is None or value == "":
+        return {}
+    parsed = json.loads(str(value))
+    if not isinstance(parsed, Mapping):
+        raise ValueError("dataset metadata must be a JSON object")
+    return dict(parsed)
 
 
 def _load_yaml(path: Path) -> Mapping[str, Any]:

--- a/crew/data_platform/public_status.py
+++ b/crew/data_platform/public_status.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+import duckdb
+import yaml
+
+from crew.data_platform.consumer import resolve_root
+
+
+_ALLOWED_CONTROLLED_STATES = {
+    "canonical_active",
+    "governed_blocked",
+    "governed_partial",
+    "private_input_required",
+}
+
+
+def build_public_status(
+    *,
+    platform_config_path: Path,
+    migration_config_path: Path,
+    root: Path | None = None,
+) -> dict[str, Any]:
+    platform_config = _load_yaml(platform_config_path)
+    migration_config = _load_yaml(migration_config_path)
+    platform_root = resolve_root(root)
+    catalog_path = platform_root / "catalog.duckdb"
+    dataset_status, latest_run = _catalog_status(catalog_path)
+
+    governed_contracts = dict(
+        platform_config.get("sources", {})
+        .get("governed_manual", {})
+        .get("datasets", {})
+    )
+    use_case_rows: list[dict[str, Any]] = []
+    active_missing = False
+    invalid_state = False
+    for slug, definition_value in dict(
+        migration_config.get("use_cases", {})
+    ).items():
+        definition = dict(definition_value or {})
+        declared_state = str(definition.get("state", "unknown"))
+        invalid_state |= declared_state not in _ALLOWED_CONTROLLED_STATES
+        required_datasets = list(definition.get("required_datasets", []))
+        required_contracts = list(definition.get("required_contracts", []))
+        missing_datasets = [
+            dataset for dataset in required_datasets if dataset not in dataset_status
+        ]
+        contract_rows = []
+        for contract_name in required_contracts:
+            contract = dict(governed_contracts.get(contract_name, {}))
+            contract_rows.append(
+                {
+                    "name": contract_name,
+                    "automation_status": contract.get(
+                        "automation_status", "unregistered"
+                    ),
+                    "checked_on": contract.get("checked_on"),
+                    "source_url": contract.get("source_url"),
+                    "block_reason": contract.get("block_reason"),
+                }
+            )
+
+        if declared_state == "canonical_active":
+            runtime_state = "ok" if not missing_datasets else "awaiting_snapshot"
+            active_missing |= bool(missing_datasets)
+        else:
+            runtime_state = declared_state
+        use_case_rows.append(
+            {
+                "slug": slug,
+                "title": definition.get("title", slug),
+                "declared_state": declared_state,
+                "runtime_state": runtime_state,
+                "operational": runtime_state != "awaiting_snapshot",
+                "owner_source": definition.get("owner_source"),
+                "note": definition.get("note"),
+                "required_datasets": required_datasets,
+                "missing_datasets": missing_datasets,
+                "required_contracts": contract_rows,
+            }
+        )
+
+    overall_status = "ok"
+    if invalid_state or active_missing:
+        overall_status = "degraded"
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "overall_status": overall_status,
+        "catalog_present": catalog_path.is_file(),
+        "latest_run": latest_run,
+        "datasets": sorted(dataset_status.values(), key=lambda row: row["dataset"]),
+        "use_cases": use_case_rows,
+        "summary": {
+            "use_case_count": len(use_case_rows),
+            "canonical_ok": sum(
+                row["runtime_state"] == "ok" for row in use_case_rows
+            ),
+            "controlled_blocks": sum(
+                row["runtime_state"]
+                in {
+                    "governed_blocked",
+                    "governed_partial",
+                    "private_input_required",
+                }
+                for row in use_case_rows
+            ),
+            "awaiting_snapshot": sum(
+                row["runtime_state"] == "awaiting_snapshot"
+                for row in use_case_rows
+            ),
+        },
+    }
+
+
+def export_public_status(
+    *,
+    output_path: Path,
+    platform_config_path: Path,
+    migration_config_path: Path,
+    root: Path | None = None,
+) -> dict[str, Any]:
+    payload = build_public_status(
+        platform_config_path=platform_config_path,
+        migration_config_path=migration_config_path,
+        root=root,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return payload
+
+
+def _catalog_status(
+    catalog_path: Path,
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any] | None]:
+    if not catalog_path.is_file():
+        return {}, None
+    with duckdb.connect(str(catalog_path), read_only=True) as connection:
+        dataset_rows = connection.execute(
+            """
+            SELECT dataset, source, row_count, raw_sha256, source_url,
+                   retrieved_at, metadata_json, run_id
+            FROM (
+                SELECT *,
+                       row_number() OVER (
+                           PARTITION BY dataset
+                           ORDER BY retrieved_at DESC, run_id DESC
+                       ) AS dataset_rank
+                FROM dataset_files
+            )
+            WHERE dataset_rank = 1
+            ORDER BY dataset
+            """
+        ).fetchall()
+        latest_run_row = connection.execute(
+            """
+            SELECT run_id, started_at, completed_at, status, error
+            FROM ingestion_runs
+            ORDER BY started_at DESC
+            LIMIT 1
+            """
+        ).fetchone()
+        failed_checks = {
+            row[0]: int(row[1])
+            for row in connection.execute(
+                """
+                SELECT dataset, count(*)
+                FROM quality_results
+                WHERE passed = false
+                GROUP BY dataset
+                """
+            ).fetchall()
+        }
+
+    status: dict[str, dict[str, Any]] = {}
+    for row in dataset_rows:
+        metadata = json.loads(row[6]) if row[6] else {}
+        status[str(row[0])] = {
+            "dataset": str(row[0]),
+            "source": str(row[1]),
+            "row_count": int(row[2]),
+            "raw_sha256": str(row[3]),
+            "source_url": str(row[4]),
+            "retrieved_at": _iso(row[5]),
+            "run_id": str(row[7]),
+            "quality_status": "ok" if failed_checks.get(str(row[0]), 0) == 0 else "failed",
+            "retrieval_mode": metadata.get("retrieval_mode"),
+            "point_in_time_vintage": metadata.get("point_in_time_vintage"),
+        }
+    latest_run = None
+    if latest_run_row:
+        latest_run = {
+            "run_id": str(latest_run_row[0]),
+            "started_at": _iso(latest_run_row[1]),
+            "completed_at": _iso(latest_run_row[2]),
+            "status": str(latest_run_row[3]),
+            "error": latest_run_row[4],
+        }
+    return status, latest_run
+
+
+def _load_yaml(path: Path) -> Mapping[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"Expected YAML mapping: {path}")
+    return payload
+
+
+def _iso(value: object) -> str | None:
+    if value is None:
+        return None
+    method = getattr(value, "isoformat", None)
+    return method() if callable(method) else str(value)

--- a/crew/data_platform/sources/fred.py
+++ b/crew/data_platform/sources/fred.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import os
 from typing import Any, Mapping, Sequence
@@ -13,13 +14,12 @@ from crew.data_platform.http import HttpClient
 class FredSource:
     name = "fred"
     BASE_URL = "https://api.stlouisfed.org/fred"
+    PUBLIC_CSV_URL = "https://fred.stlouisfed.org/graph/fredgraph.csv"
 
     def __init__(self, config: Mapping[str, Any]) -> None:
         self.config = config
         api_key_env = str(config.get("api_key_env", "FRED_API_KEY"))
         self.api_key = os.environ.get(api_key_env, "").strip()
-        if not self.api_key:
-            raise RuntimeError(f"FRED API key is required in {api_key_env}.")
         self.client = HttpClient(
             user_agent=str(config.get("user_agent", "CrewTrade data-platform")),
             min_interval_seconds=float(config.get("min_interval_seconds", 0.25)),
@@ -29,50 +29,45 @@ class FredSource:
         batches: list[DatasetBatch] = []
         for dataset_name, dataset_config in dict(self.config.get("datasets", {})).items():
             rows: list[dict[str, object]] = []
-            raw_bundle: dict[str, object] = {"dataset": dataset_name, "series": {}}
+            retrieval_mode = "api_vintage" if self.api_key else "public_csv_snapshot"
+            raw_bundle: dict[str, object] = {
+                "dataset": dataset_name,
+                "retrieval_mode": retrieval_mode,
+                "series": {},
+            }
             latest_url = ""
             latest_retrieved_at = None
             series_map = dict(dataset_config.get("series", {}))
             for label, series_id_value in series_map.items():
                 series_id = str(series_id_value)
-                metadata_payload = self.client.get(
-                    f"{self.BASE_URL}/series",
-                    params={
-                        "api_key": self.api_key,
-                        "file_type": "json",
-                        "series_id": series_id,
-                    },
-                )
-                observations_payload = self.client.get(
-                    f"{self.BASE_URL}/series/observations",
-                    params={
-                        "api_key": self.api_key,
-                        "file_type": "json",
-                        "series_id": series_id,
-                        "observation_start": dataset_config.get(
-                            "observation_start", "1900-01-01"
-                        ),
-                        "sort_order": "asc",
-                        "output_type": 1,
-                    },
-                )
-                metadata_json = json.loads(metadata_payload.body)
-                observations_json = json.loads(observations_payload.body)
-                raw_bundle["series"][series_id] = {
-                    "label": label,
-                    "metadata": metadata_json,
-                    "observations": observations_json,
-                }
-                rows.extend(
-                    parse_fred_series(
-                        label=label,
-                        series_id=series_id,
-                        metadata=metadata_json,
-                        observations=observations_json,
+                if self.api_key:
+                    series_rows, raw_record, source_url, retrieved_at = (
+                        self._fetch_api_series(
+                            label=label,
+                            series_id=series_id,
+                            observation_start=str(
+                                dataset_config.get(
+                                    "observation_start", "1900-01-01"
+                                )
+                            ),
+                        )
                     )
-                )
-                latest_url = observations_payload.url
-                latest_retrieved_at = observations_payload.retrieved_at
+                else:
+                    series_rows, raw_record, source_url, retrieved_at = (
+                        self._fetch_public_csv_series(
+                            label=label,
+                            series_id=series_id,
+                            observation_start=str(
+                                dataset_config.get(
+                                    "observation_start", "1900-01-01"
+                                )
+                            ),
+                        )
+                    )
+                rows.extend(series_rows)
+                raw_bundle["series"][series_id] = raw_record
+                latest_url = source_url
+                latest_retrieved_at = retrieved_at
             frame = pd.DataFrame.from_records(rows)
             batches.append(
                 DatasetBatch(
@@ -85,7 +80,8 @@ class FredSource:
                         "realtime_start",
                         "realtime_end",
                     ),
-                    source_url=latest_url or f"{self.BASE_URL}/series/observations",
+                    source_url=latest_url
+                    or f"{self.BASE_URL}/series/observations",
                     raw_payload=json.dumps(
                         raw_bundle, ensure_ascii=False, sort_keys=True
                     ).encode("utf-8"),
@@ -93,10 +89,79 @@ class FredSource:
                     retrieved_at=latest_retrieved_at
                     if latest_retrieved_at is not None
                     else pd.Timestamp.utcnow().to_pydatetime(),
-                    metadata={"series_count": len(series_map)},
+                    metadata={
+                        "series_count": len(series_map),
+                        "retrieval_mode": retrieval_mode,
+                        "point_in_time_vintage": bool(self.api_key),
+                    },
                 )
             )
         return batches
+
+    def _fetch_api_series(
+        self, *, label: str, series_id: str, observation_start: str
+    ) -> tuple[list[dict[str, object]], dict[str, object], str, object]:
+        metadata_payload = self.client.get(
+            f"{self.BASE_URL}/series",
+            params={
+                "api_key": self.api_key,
+                "file_type": "json",
+                "series_id": series_id,
+            },
+        )
+        observations_payload = self.client.get(
+            f"{self.BASE_URL}/series/observations",
+            params={
+                "api_key": self.api_key,
+                "file_type": "json",
+                "series_id": series_id,
+                "observation_start": observation_start,
+                "sort_order": "asc",
+                "output_type": 1,
+            },
+        )
+        metadata_json = json.loads(metadata_payload.body)
+        observations_json = json.loads(observations_payload.body)
+        return (
+            parse_fred_series(
+                label=label,
+                series_id=series_id,
+                metadata=metadata_json,
+                observations=observations_json,
+            ),
+            {
+                "label": label,
+                "metadata": metadata_json,
+                "observations": observations_json,
+            },
+            observations_payload.url,
+            observations_payload.retrieved_at,
+        )
+
+    def _fetch_public_csv_series(
+        self, *, label: str, series_id: str, observation_start: str
+    ) -> tuple[list[dict[str, object]], dict[str, object], str, object]:
+        payload = self.client.get(
+            self.PUBLIC_CSV_URL,
+            params={"id": series_id, "cosd": observation_start},
+        )
+        retrieval_date = pd.Timestamp(payload.retrieved_at).date()
+        rows = parse_fred_public_csv(
+            label=label,
+            series_id=series_id,
+            payload=payload.body,
+            retrieval_date=retrieval_date,
+        )
+        return (
+            rows,
+            {
+                "label": label,
+                "retrieval_mode": "public_csv_snapshot",
+                "csv": payload.body.decode("utf-8"),
+            },
+            payload.url,
+            payload.retrieved_at,
+        )
 
 
 def parse_fred_series(
@@ -133,3 +198,36 @@ def parse_fred_series(
             }
         )
     return rows
+
+
+def parse_fred_public_csv(
+    *,
+    label: str,
+    series_id: str,
+    payload: bytes,
+    retrieval_date: object,
+) -> list[dict[str, object]]:
+    frame = pd.read_csv(io.BytesIO(payload))
+    if "DATE" not in frame.columns or series_id not in frame.columns:
+        raise ValueError(
+            f"Unexpected FRED CSV columns for {series_id}: {list(frame.columns)}"
+        )
+    frame[series_id] = pd.to_numeric(frame[series_id], errors="coerce")
+    frame = frame.dropna(subset=[series_id])
+    snapshot_date = pd.to_datetime(retrieval_date).date()
+    return [
+        {
+            "series_id": series_id,
+            "label": label,
+            "observation_date": pd.to_datetime(row.DATE).date(),
+            "value": float(getattr(row, series_id)),
+            "realtime_start": snapshot_date,
+            "realtime_end": snapshot_date,
+            "frequency": None,
+            "units": None,
+            "seasonal_adjustment": None,
+            "last_updated": snapshot_date,
+            "title": series_id,
+        }
+        for row in frame.itertuples(index=False)
+    ]

--- a/crew/data_platform/sources/fred.py
+++ b/crew/data_platform/sources/fred.py
@@ -27,9 +27,13 @@ class FredSource:
 
     def fetch(self) -> Sequence[DatasetBatch]:
         batches: list[DatasetBatch] = []
-        for dataset_name, dataset_config in dict(self.config.get("datasets", {})).items():
+        for dataset_name, dataset_config in dict(
+            self.config.get("datasets", {})
+        ).items():
             rows: list[dict[str, object]] = []
-            retrieval_mode = "api_vintage" if self.api_key else "public_csv_snapshot"
+            retrieval_mode = (
+                "api_vintage" if self.api_key else "public_csv_snapshot"
+            )
             raw_bundle: dict[str, object] = {
                 "dataset": dataset_name,
                 "retrieval_mode": retrieval_mode,
@@ -40,16 +44,15 @@ class FredSource:
             series_map = dict(dataset_config.get("series", {}))
             for label, series_id_value in series_map.items():
                 series_id = str(series_id_value)
+                observation_start = str(
+                    dataset_config.get("observation_start", "1900-01-01")
+                )
                 if self.api_key:
                     series_rows, raw_record, source_url, retrieved_at = (
                         self._fetch_api_series(
                             label=label,
                             series_id=series_id,
-                            observation_start=str(
-                                dataset_config.get(
-                                    "observation_start", "1900-01-01"
-                                )
-                            ),
+                            observation_start=observation_start,
                         )
                     )
                 else:
@@ -57,11 +60,7 @@ class FredSource:
                         self._fetch_public_csv_series(
                             label=label,
                             series_id=series_id,
-                            observation_start=str(
-                                dataset_config.get(
-                                    "observation_start", "1900-01-01"
-                                )
-                            ),
+                            observation_start=observation_start,
                         )
                     )
                 rows.extend(series_rows)
@@ -86,9 +85,11 @@ class FredSource:
                         raw_bundle, ensure_ascii=False, sort_keys=True
                     ).encode("utf-8"),
                     content_type="application/json",
-                    retrieved_at=latest_retrieved_at
-                    if latest_retrieved_at is not None
-                    else pd.Timestamp.utcnow().to_pydatetime(),
+                    retrieved_at=(
+                        latest_retrieved_at
+                        if latest_retrieved_at is not None
+                        else pd.Timestamp.utcnow().to_pydatetime()
+                    ),
                     metadata={
                         "series_count": len(series_map),
                         "retrieval_mode": retrieval_mode,
@@ -208,26 +209,37 @@ def parse_fred_public_csv(
     retrieval_date: object,
 ) -> list[dict[str, object]]:
     frame = pd.read_csv(io.BytesIO(payload))
-    if "DATE" not in frame.columns or series_id not in frame.columns:
+    date_column = next(
+        (
+            candidate
+            for candidate in ("observation_date", "DATE", "date")
+            if candidate in frame.columns
+        ),
+        None,
+    )
+    if date_column is None or series_id not in frame.columns:
         raise ValueError(
             f"Unexpected FRED CSV columns for {series_id}: {list(frame.columns)}"
         )
     frame[series_id] = pd.to_numeric(frame[series_id], errors="coerce")
-    frame = frame.dropna(subset=[series_id])
+    frame[date_column] = pd.to_datetime(frame[date_column], errors="coerce")
+    frame = frame.dropna(subset=[date_column, series_id])
     snapshot_date = pd.to_datetime(retrieval_date).date()
-    return [
-        {
-            "series_id": series_id,
-            "label": label,
-            "observation_date": pd.to_datetime(row.DATE).date(),
-            "value": float(getattr(row, series_id)),
-            "realtime_start": snapshot_date,
-            "realtime_end": snapshot_date,
-            "frequency": None,
-            "units": None,
-            "seasonal_adjustment": None,
-            "last_updated": snapshot_date,
-            "title": series_id,
-        }
-        for row in frame.itertuples(index=False)
-    ]
+    rows: list[dict[str, object]] = []
+    for record in frame[[date_column, series_id]].to_dict(orient="records"):
+        rows.append(
+            {
+                "series_id": series_id,
+                "label": label,
+                "observation_date": pd.Timestamp(record[date_column]).date(),
+                "value": float(record[series_id]),
+                "realtime_start": snapshot_date,
+                "realtime_end": snapshot_date,
+                "frequency": None,
+                "units": None,
+                "seasonal_adjustment": None,
+                "last_updated": snapshot_date,
+                "title": series_id,
+            }
+        )
+    return rows

--- a/crew/data_platform/sources/sec.py
+++ b/crew/data_platform/sources/sec.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import os
 from typing import Any, Mapping, Sequence
+from xml.etree import ElementTree
 
 import pandas as pd
 
@@ -14,6 +16,7 @@ from crew.data_platform.http import HttpClient
 class SecSource:
     name = "sec_edgar"
     DATA_BASE_URL = "https://data.sec.gov"
+    ARCHIVES_BASE_URL = "https://www.sec.gov/Archives/edgar/data"
 
     def __init__(self, config: Mapping[str, Any]) -> None:
         self.config = config
@@ -34,6 +37,7 @@ class SecSource:
     def fetch(self) -> Sequence[DatasetBatch]:
         filing_rows: list[dict[str, object]] = []
         fact_rows: list[dict[str, object]] = []
+        holding_rows: list[dict[str, object]] = []
         raw_bundle: dict[str, object] = {"entities": {}}
         latest_url = self.DATA_BASE_URL
         latest_retrieved_at = None
@@ -44,11 +48,10 @@ class SecSource:
                 f"{self.DATA_BASE_URL}/submissions/CIK{cik}.json"
             )
             submissions_json = json.loads(submissions_payload.body)
-            filing_rows.extend(
-                parse_sec_submissions(
-                    entity_name=str(entity_name), cik=cik, payload=submissions_json
-                )
+            entity_filings = parse_sec_submissions(
+                entity_name=str(entity_name), cik=cik, payload=submissions_json
             )
+            filing_rows.extend(entity_filings)
             entity_raw: dict[str, object] = {"submissions": submissions_json}
             latest_url = submissions_payload.url
             latest_retrieved_at = submissions_payload.retrieved_at
@@ -66,6 +69,21 @@ class SecSource:
                 entity_raw["companyfacts"] = facts_json
                 latest_url = facts_payload.url
                 latest_retrieved_at = facts_payload.retrieved_at
+
+            if bool(entity_config.get("thirteen_f_information_table", False)):
+                holdings, documents, document_url, retrieved_at = self._fetch_13f_tables(
+                    entity_name=str(entity_name),
+                    cik=cik,
+                    filings=entity_filings,
+                    history_limit=int(entity_config.get("history_limit", 8)),
+                )
+                holding_rows.extend(holdings)
+                entity_raw["thirteen_f_documents"] = documents
+                if document_url:
+                    latest_url = document_url
+                if retrieved_at is not None:
+                    latest_retrieved_at = retrieved_at
+
             raw_bundle["entities"][entity_name] = entity_raw
 
         raw_payload = json.dumps(
@@ -105,7 +123,90 @@ class SecSource:
                     metadata={"entity_count": len(self.config.get("entities", {}))},
                 )
             )
+        if holding_rows:
+            batches.append(
+                DatasetBatch(
+                    dataset="sec_13f_holdings",
+                    source=self.name,
+                    frame=pd.DataFrame.from_records(holding_rows),
+                    primary_key=("holding_id",),
+                    source_url=latest_url,
+                    raw_payload=raw_payload,
+                    content_type="application/json",
+                    retrieved_at=retrieved_at,
+                    metadata={"filing_count": len({row["accession_number"] for row in holding_rows})},
+                )
+            )
         return batches
+
+    def _fetch_13f_tables(
+        self,
+        *,
+        entity_name: str,
+        cik: str,
+        filings: Sequence[Mapping[str, object]],
+        history_limit: int,
+    ) -> tuple[list[dict[str, object]], list[dict[str, object]], str, object | None]:
+        eligible = [
+            filing
+            for filing in filings
+            if str(filing.get("form")) in {"13F-HR", "13F-HR/A"}
+        ]
+        eligible.sort(
+            key=lambda item: (
+                str(item.get("report_date") or ""),
+                str(item.get("filing_date") or ""),
+            ),
+            reverse=True,
+        )
+        rows: list[dict[str, object]] = []
+        documents: list[dict[str, object]] = []
+        latest_url = ""
+        latest_retrieved_at = None
+        for filing in eligible[: max(1, history_limit)]:
+            accession = str(filing["accession_number"])
+            compact_accession = accession.replace("-", "")
+            archive_cik = str(int(cik))
+            directory_url = (
+                f"{self.ARCHIVES_BASE_URL}/{archive_cik}/{compact_accession}"
+            )
+            index_payload = self.client.get(f"{directory_url}/index.json")
+            index_json = json.loads(index_payload.body)
+            candidates = _information_table_candidates(index_json)
+            filing_document: dict[str, object] = {
+                "accession_number": accession,
+                "index_url": index_payload.url,
+                "index": index_json,
+                "information_tables": [],
+            }
+            for filename in candidates:
+                document_payload = self.client.get(f"{directory_url}/{filename}")
+                parsed = parse_13f_information_table(
+                    entity_name=entity_name,
+                    cik=cik,
+                    accession_number=accession,
+                    report_date=filing.get("report_date"),
+                    filing_date=filing.get("filing_date"),
+                    source_url=document_payload.url,
+                    payload=document_payload.body,
+                )
+                if not parsed:
+                    continue
+                rows.extend(parsed)
+                filing_document["information_tables"].append(
+                    {
+                        "filename": filename,
+                        "url": document_payload.url,
+                        "body_base64": base64.b64encode(document_payload.body).decode(
+                            "ascii"
+                        ),
+                    }
+                )
+                latest_url = document_payload.url
+                latest_retrieved_at = document_payload.retrieved_at
+                break
+            documents.append(filing_document)
+        return rows, documents, latest_url, latest_retrieved_at
 
 
 def parse_sec_submissions(
@@ -185,6 +286,110 @@ def parse_sec_companyfacts(
                         }
                     )
     return rows
+
+
+def parse_13f_information_table(
+    *,
+    entity_name: str,
+    cik: str,
+    accession_number: str,
+    report_date: object,
+    filing_date: object,
+    source_url: str,
+    payload: bytes,
+) -> list[dict[str, object]]:
+    try:
+        root = ElementTree.fromstring(payload)
+    except ElementTree.ParseError:
+        return []
+    rows: list[dict[str, object]] = []
+    for position, node in enumerate(
+        element for element in root.iter() if _local_name(element.tag) == "infoTable"
+    ):
+        issuer = _descendant_text(node, "nameOfIssuer")
+        cusip = _descendant_text(node, "cusip")
+        if not issuer or not cusip:
+            continue
+        canonical = {
+            "entity_cik": cik,
+            "accession_number": accession_number,
+            "position": position,
+            "issuer": issuer,
+            "title_of_class": _descendant_text(node, "titleOfClass"),
+            "cusip": cusip,
+            "put_call": _descendant_text(node, "putCall"),
+        }
+        holding_id = hashlib.sha256(
+            json.dumps(canonical, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        ).hexdigest()
+        rows.append(
+            {
+                "holding_id": holding_id,
+                "entity_name": entity_name,
+                "entity_cik": cik,
+                "accession_number": accession_number,
+                "report_date": _to_date(report_date),
+                "filing_date": _to_date(filing_date),
+                "issuer": issuer,
+                "title_of_class": canonical["title_of_class"],
+                "cusip": cusip,
+                "figi": _descendant_text(node, "figi"),
+                "reported_value": _to_number(_descendant_text(node, "value")),
+                "reported_value_unit": "SEC_13F_as_filed",
+                "shares_or_principal": _to_number(
+                    _descendant_text(node, "sshPrnamt")
+                ),
+                "shares_or_principal_type": _descendant_text(
+                    node, "sshPrnamtType"
+                ),
+                "put_call": canonical["put_call"],
+                "investment_discretion": _descendant_text(
+                    node, "investmentDiscretion"
+                ),
+                "other_manager": _descendant_text(node, "otherManager"),
+                "voting_sole": _to_number(_descendant_text(node, "Sole")),
+                "voting_shared": _to_number(_descendant_text(node, "Shared")),
+                "voting_none": _to_number(_descendant_text(node, "None")),
+                "source_document_url": source_url,
+            }
+        )
+    return rows
+
+
+def _information_table_candidates(index_payload: Mapping[str, Any]) -> list[str]:
+    items = index_payload.get("directory", {}).get("item", [])
+    names = [str(item.get("name", "")) for item in items]
+    xml_names = [name for name in names if name.lower().endswith(".xml")]
+    preferred = [
+        name
+        for name in xml_names
+        if "info" in name.lower() and "table" in name.lower()
+    ]
+    return preferred + [name for name in xml_names if name not in preferred]
+
+
+def _descendant_text(node: ElementTree.Element, name: str) -> str | None:
+    for child in node.iter():
+        if _local_name(child.tag).lower() == name.lower():
+            text = (child.text or "").strip()
+            return text or None
+    return None
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _to_number(value: object | None) -> float | None:
+    if value is None:
+        return None
+    text = str(value).replace(",", "").strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
 
 
 def _value_at(payload: Mapping[str, Any], key: str, index: int) -> object | None:

--- a/crew/legendary_investors/analysis.py
+++ b/crew/legendary_investors/analysis.py
@@ -1,127 +1,238 @@
-"""Analysis module for legendary investors portfolios."""
-from dataclasses import dataclass
-from typing import Any, Dict, List
-import numpy as np
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from typing import Any, Dict
+from zoneinfo import ZoneInfo
+
 import pandas as pd
-from .config import LegendaryInvestorsConfig
-from .deep_research import LegendaryInvestorsResearcher
-@dataclass
-class HoldingMetrics:
-    symbol: str
-    current_price: float
-    return_1m: float
-    return_3m: float
-    return_6m: float
-    return_12m: float
-    ytd_return: float
-    volatility: float
-    sharpe_ratio: float
-    max_drawdown: float
-    fundamentals: str = ""
-    news_summary: str = ""
-    reason_why: str = ""
-    evaluation: str = ""
-    rumor: str = ""
-    earnings: str = ""
-    alpha: str = ""
+import yaml
+
+from crew.legendary_investors.config import LegendaryInvestorsConfig
+
+
 class LegendaryInvestorsAnalyzer:
-    """Analyzer for legendary investors' top holdings."""
-    RISK_FREE_RATE = 0.045
+    """Analyze point-in-time 13F information tables instead of fixed ticker lists."""
+
     def __init__(
         self, config: LegendaryInvestorsConfig, raw_data_dir: Any = None
     ) -> None:
         self.config = config
-        self.researcher = LegendaryInvestorsResearcher()
-        self.raw_data_dir = raw_data_dir
+        self.raw_data_dir = Path(raw_data_dir) if raw_data_dir else None
+
     def analyze(self, data_payload: Dict[str, Any]) -> Dict[str, Any]:
-        price_frames = data_payload.get("price_frames", {})
-        if not price_frames and self.raw_data_dir:
-            from pathlib import Path
-            raw = Path(self.raw_data_dir)
-            tickers = list(
-                set(
-                    self.config.soros_holdings
-                    + self.config.druckenmiller_holdings
-                    + [self.config.benchmark]
+        filings = self._load_frame(data_payload.get("filings"), "filings.parquet")
+        holdings = self._load_frame(data_payload.get("holdings"), "holdings.parquet")
+        for column in ("filing_date", "report_date", "acceptance_datetime", "_retrieved_at"):
+            if column in filings.columns:
+                filings[column] = pd.to_datetime(filings[column])
+        for column in ("report_date", "filing_date", "_retrieved_at"):
+            if column in holdings.columns:
+                holdings[column] = pd.to_datetime(holdings[column])
+        holdings["reported_value"] = pd.to_numeric(
+            holdings["reported_value"], errors="coerce"
+        )
+        holdings["shares_or_principal"] = pd.to_numeric(
+            holdings["shares_or_principal"], errors="coerce"
+        )
+        holdings = (
+            holdings.sort_values("_retrieved_at", ascending=False)
+            .drop_duplicates("holding_id", keep="first")
+            .reset_index(drop=True)
+        )
+
+        manager_summaries: list[dict[str, object]] = []
+        latest_tables: list[pd.DataFrame] = []
+        change_tables: list[pd.DataFrame] = []
+        for manager_name, manager_config in self.config.managers.items():
+            manager_holdings = holdings[
+                holdings["entity_name"] == manager_name
+            ].copy()
+            report_dates = sorted(
+                manager_holdings["report_date"].dropna().unique(), reverse=True
+            )
+            if not report_dates:
+                continue
+            latest_date = pd.Timestamp(report_dates[0])
+            previous_date = (
+                pd.Timestamp(report_dates[1]) if len(report_dates) > 1 else None
+            )
+            latest = manager_holdings[
+                manager_holdings["report_date"] == latest_date
+            ].copy()
+            latest = self._aggregate_positions(latest)
+            total_value = latest["reported_value"].sum(min_count=1)
+            latest["portfolio_weight"] = (
+                latest["reported_value"] / total_value
+                if pd.notna(total_value) and total_value != 0
+                else pd.NA
+            )
+            latest["manager"] = manager_name
+            latest["manager_display_name"] = manager_config.display_name
+            latest_tables.append(
+                latest.sort_values("reported_value", ascending=False).head(
+                    self.config.top_holdings_limit
                 )
             )
-            for t in tickers:
-                p = raw / f"{t}.parquet"
-                if p.exists():
-                    price_frames[t] = pd.read_parquet(p)
-        if not price_frames:
-            return {"error": "No price data available"}
-        soros_metrics = self._analyze_portfolio(
-            self.config.soros_holdings, price_frames
+
+            changes = pd.DataFrame()
+            if previous_date is not None:
+                previous = self._aggregate_positions(
+                    manager_holdings[
+                        manager_holdings["report_date"] == previous_date
+                    ].copy()
+                )
+                changes = self._compare_positions(latest, previous)
+                changes["manager"] = manager_name
+                changes["manager_display_name"] = manager_config.display_name
+                change_tables.append(changes)
+
+            latest_filing = filings[
+                (filings["entity_name"] == manager_name)
+                & (filings["report_date"] == latest_date)
+            ].sort_values("filing_date", ascending=False)
+            filing_date = (
+                pd.Timestamp(latest_filing.iloc[0]["filing_date"])
+                if not latest_filing.empty
+                else pd.Timestamp(latest["filing_date"].max())
+            )
+            manager_summaries.append(
+                {
+                    "manager": manager_name,
+                    "manager_display_name": manager_config.display_name,
+                    "latest_report_date": latest_date,
+                    "previous_report_date": previous_date,
+                    "filing_date": filing_date,
+                    "filing_lag_days": (filing_date - latest_date).days,
+                    "position_count": len(latest),
+                    "reported_value_total": total_value,
+                    "history_quarters": len(report_dates),
+                    "comparison_ready": len(report_dates)
+                    >= self.config.minimum_history_quarters,
+                }
+            )
+
+        summary = pd.DataFrame(manager_summaries)
+        latest_holdings = (
+            pd.concat(latest_tables, ignore_index=True)
+            if latest_tables
+            else pd.DataFrame()
         )
-        druckenmiller_metrics = self._analyze_portfolio(
-            self.config.druckenmiller_holdings, price_frames
+        changes = (
+            pd.concat(change_tables, ignore_index=True)
+            if change_tables
+            else pd.DataFrame()
         )
         return {
-            "soros_metrics": soros_metrics,
-            "druckenmiller_metrics": druckenmiller_metrics,
-            "analysis_date": pd.Timestamp.now().strftime("%Y-%m-%d"),
+            "filings": filings,
+            "holdings": holdings,
+            "manager_summary": summary,
+            "latest_holdings": latest_holdings,
+            "quarter_changes": changes,
+            "analysis_date": pd.Timestamp.now(tz="UTC"),
         }
-    def _analyze_portfolio(
-        self, tickers: List[str], frames: Dict[str, pd.DataFrame]
-    ) -> List[HoldingMetrics]:
-        metrics_list = []
-        for ticker in tickers:
-            df = frames.get(ticker)
-            if df is None or df.empty:
-                continue
-            col = "Adj Close" if "Adj Close" in df.columns else "Close"
-            prices = df[col].dropna()
-            if len(prices) < 20:
-                continue
-            current_price = float(prices.iloc[-1])
-            ret_1m = self._calc_period_return(prices, 21)
-            ret_3m = self._calc_period_return(prices, 63)
-            ret_6m = self._calc_period_return(prices, 126)
-            ret_12m = self._calc_period_return(prices, 252)
-            ytd = self._calc_ytd_return(prices)
-            returns = prices.pct_change().dropna()
-            vol = float(returns.std() * np.sqrt(252))
-            excess_return = ret_12m - self.RISK_FREE_RATE
-            sharpe = excess_return / vol if vol > 0 else 0.0
-            cummax = prices.cummax()
-            drawdown = (prices - cummax) / cummax
-            max_dd = float(drawdown.min())
-            research_data = self.researcher.get_research_for_ticker(ticker)
-            metrics_list.append(
-                HoldingMetrics(
-                    symbol=ticker,
-                    current_price=current_price,
-                    return_1m=ret_1m,
-                    return_3m=ret_3m,
-                    return_6m=ret_6m,
-                    return_12m=ret_12m,
-                    ytd_return=ytd,
-                    volatility=vol,
-                    sharpe_ratio=sharpe,
-                    max_drawdown=max_dd,
-                    fundamentals=research_data.get("fundamentals", ""),
-                    news_summary=research_data.get("news_summary", ""),
-                    reason_why=research_data.get("reason_why", ""),
-                    evaluation=research_data.get("evaluation", ""),
-                    rumor=research_data.get("rumor", ""),
-                    earnings=research_data.get("earnings", ""),
-                    alpha=research_data.get("alpha", ""),
-                )
-            )
-        metrics_list.sort(key=lambda x: x.return_12m, reverse=True)
-        return metrics_list
-    def _calc_period_return(self, prices: pd.Series, days: int) -> float:
-        if len(prices) < days:
-            days = len(prices)
-        start = float(prices.iloc[-days])
-        end = float(prices.iloc[-1])
-        return (end - start) / start if start > 0 else 0.0
-    def _calc_ytd_return(self, prices: pd.Series) -> float:
-        current_year = pd.Timestamp.now().year
-        ytd = prices[prices.index.year == current_year]
-        if len(ytd) < 2:
-            return 0.0
-        start = float(ytd.iloc[0])
-        end = float(ytd.iloc[-1])
-        return (end - start) / start if start > 0 else 0.0
+
+    evaluate = analyze
+
+    def _load_frame(self, value: object, filename: str) -> pd.DataFrame:
+        if isinstance(value, pd.DataFrame):
+            return value.copy()
+        if isinstance(value, (str, Path)) and Path(value).is_file():
+            return pd.read_parquet(value)
+        if self.raw_data_dir is not None:
+            path = self.raw_data_dir / filename
+            if path.is_file():
+                return pd.read_parquet(path)
+        raise FileNotFoundError(
+            f"Canonical investor export {filename} is missing. "
+            "Run `task fetch:legendary_investors`."
+        )
+
+    @staticmethod
+    def _aggregate_positions(frame: pd.DataFrame) -> pd.DataFrame:
+        keys = ["cusip", "issuer", "title_of_class", "put_call"]
+        aggregations = {
+            "reported_value": "sum",
+            "shares_or_principal": "sum",
+            "shares_or_principal_type": "first",
+            "accession_number": "first",
+            "report_date": "first",
+            "filing_date": "max",
+            "source_document_url": "first",
+            "_source_url": "first",
+            "_raw_sha256": "first",
+        }
+        available = {
+            key: value
+            for key, value in aggregations.items()
+            if key in frame.columns
+        }
+        return frame.groupby(keys, dropna=False, as_index=False).agg(available)
+
+    @staticmethod
+    def _compare_positions(latest: pd.DataFrame, previous: pd.DataFrame) -> pd.DataFrame:
+        keys = ["cusip", "issuer", "title_of_class", "put_call"]
+        left = latest[keys + ["reported_value", "shares_or_principal"]].rename(
+            columns={
+                "reported_value": "latest_value",
+                "shares_or_principal": "latest_shares",
+            }
+        )
+        right = previous[keys + ["reported_value", "shares_or_principal"]].rename(
+            columns={
+                "reported_value": "previous_value",
+                "shares_or_principal": "previous_shares",
+            }
+        )
+        compared = left.merge(right, on=keys, how="outer")
+        compared["value_change"] = (
+            compared["latest_value"].fillna(0)
+            - compared["previous_value"].fillna(0)
+        )
+        compared["share_change"] = (
+            compared["latest_shares"].fillna(0)
+            - compared["previous_shares"].fillna(0)
+        )
+
+        def classify(row: pd.Series) -> str:
+            if pd.isna(row["previous_shares"]):
+                return "new"
+            if pd.isna(row["latest_shares"]):
+                return "exited"
+            if row["share_change"] > 0:
+                return "increased"
+            if row["share_change"] < 0:
+                return "decreased"
+            return "unchanged"
+
+        compared["change_type"] = compared.apply(classify, axis=1)
+        return compared.sort_values("value_change", key=lambda values: values.abs(), ascending=False)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+CONFIG_FILE = PROJECT_ROOT / "config" / "use_cases" / "legendary_investors.yaml"
+DATA_DIR = PROJECT_ROOT / "data" / "legendary_investors"
+
+
+def main() -> None:
+    from crew.legendary_investors.reporting import LegendaryInvestorsReporter
+
+    config = LegendaryInvestorsConfig(
+        **yaml.safe_load(CONFIG_FILE.read_text(encoding="utf-8"))
+    )
+    analyzer = LegendaryInvestorsAnalyzer(config, DATA_DIR)
+    result = analyzer.analyze({})
+    report_date = datetime.datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y%m%d")
+    reporter = LegendaryInvestorsReporter(
+        PROJECT_ROOT
+        / "output"
+        / "use_cases"
+        / "legendary_investors"
+        / report_date
+    )
+    stored = reporter.produce_report(result)
+    print(f"Canonical investor report: {stored['report_file']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crew/legendary_investors/config.py
+++ b/crew/legendary_investors/config.py
@@ -1,23 +1,23 @@
-from typing import List
+from __future__ import annotations
+
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
 from crew.base import UseCaseConfig
+
+
+class ManagerConfig(BaseModel):
+    display_name: str
+    cik: str
+
+
 class LegendaryInvestorsConfig(UseCaseConfig):
-    """Configuration for legendary investors portfolio tracking."""
-    soros_holdings: List[str] = [
-        "AMZN",
-        "SW",
-        "GOOGL",
-        "RSP",
-        "TKO",
-    ]
-    druckenmiller_holdings: List[str] = [
-        "NTRA",
-        "INSM",
-        "TEVA",
-        "TSM",
-        "WWD",
-        "CPNG",
-        "MELI",
-        "DOCU",
-    ]
-    period: str = "1y"
-    benchmark: str = "SPY"
+    forms: List[str] = Field(default_factory=lambda: ["13F-HR", "13F-HR/A"])
+    managers: Dict[str, ManagerConfig] = Field(default_factory=dict)
+    minimum_history_quarters: int = Field(default=2, ge=2)
+    top_holdings_limit: int = Field(default=20, ge=1, le=100)
+
+    @property
+    def manager_names(self) -> list[str]:
+        return list(self.managers)

--- a/crew/legendary_investors/data_pipeline.py
+++ b/crew/legendary_investors/data_pipeline.py
@@ -1,23 +1,54 @@
-"""Data flow for legendary investors use case."""
+from __future__ import annotations
+
 from pathlib import Path
-from crew.clients.equities import YFinanceEquityDataClient
-def fetch_investor_data(
-    tickers: list[str],
-    raw_data_dir: Path,
-    period: str = "1y",
-) -> dict:
-    """Fetch and cache price data for investor holdings."""
-    raw_data_dir.mkdir(parents=True, exist_ok=True)
-    client = YFinanceEquityDataClient(raw_data_dir)
-    frames = client.get_frames(tickers, period=period)
-    return frames
-if __name__ == "__main__":
-    from crew.legendary_investors.config import LegendaryInvestorsConfig
-    config = LegendaryInvestorsConfig(name="legendary_investors")
-    all_tickers = list(
-        set(config.soros_holdings + config.druckenmiller_holdings + [config.benchmark])
+from typing import Dict
+
+from crew.app import BaseDataPipeline, GenericUseCase
+from crew.data_platform.consumer import sec_13f_holdings, sec_filings
+from crew.legendary_investors.config import LegendaryInvestorsConfig
+
+
+class LegendaryInvestorsDataPipeline(BaseDataPipeline):
+    """Export 13F filings and information-table holdings from canonical SEC data."""
+
+    def __init__(self, raw_data_dir: Path, config: LegendaryInvestorsConfig) -> None:
+        super().__init__(raw_data_dir, config)
+
+    def fetch_data_internal(self, targets: Dict[str, str], days: int) -> Dict[str, str]:
+        manager_names = self.config.manager_names
+        filings = sec_filings(
+            entity_names=manager_names,
+            forms=self.config.forms,
+        )
+        holdings = sec_13f_holdings(
+            entity_names=manager_names,
+            latest_only=False,
+        )
+        self._save("filings", filings)
+        self._save("holdings", holdings)
+        return {
+            "filings": str(self.raw_data_dir / "filings.parquet"),
+            "holdings": str(self.raw_data_dir / "holdings.parquet"),
+        }
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+CONFIG_FILE = PROJECT_ROOT / "config" / "use_cases" / "legendary_investors.yaml"
+
+
+def main() -> None:
+    from crew.legendary_investors.analysis import LegendaryInvestorsAnalyzer
+
+    use_case = GenericUseCase(
+        config_path=CONFIG_FILE,
+        pipeline_class=LegendaryInvestorsDataPipeline,
+        analyzer_class=LegendaryInvestorsAnalyzer,
+        config_class=LegendaryInvestorsConfig,
     )
-    raw_dir = Path("resources") / "data" / "use_cases" / "legendary_investors" / "raw"
-    print(f"Fetching data for {len(all_tickers)} tickers...")
-    frames = fetch_investor_data(all_tickers, raw_dir, config.period)
-    print(f"Fetched {len(frames)} ticker(s)")
+    saved_files = use_case.fetch_data()
+    for name, path in saved_files.items():
+        print(f"Saved canonical investor {name}: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crew/legendary_investors/reporting.py
+++ b/crew/legendary_investors/reporting.py
@@ -1,83 +1,188 @@
-"""Reporting module for legendary investors use case."""
+from __future__ import annotations
+
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
-from .analysis import HoldingMetrics
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+
+
 class LegendaryInvestorsReporter:
-    """Generates markdown reports for legendary investors analysis."""
+    """Generate evidence-bound reports from SEC 13F information tables."""
+
     def __init__(self, report_dir: Path) -> None:
         self.report_dir = report_dir
         self.report_dir.mkdir(parents=True, exist_ok=True)
-    def produce_report(self, analysis_payload: Dict[str, Any]) -> Dict[str, Any]:
-        druckenmiller = analysis_payload.get("druckenmiller_metrics", [])
-        date = analysis_payload.get("analysis_date", "Unknown Date")
-        forecasts = analysis_payload.get("forecasts", {})
-        md_lines = [
-            f"
-            "",
-            "
-            "Top holdings based on recent 13F filings.",
-            "",
-            self._make_detailed_section(soros),
-            "",
-            "
-            "Top holdings based on recent 13F filings.",
-            "",
-            self._make_detailed_section(druckenmiller),
-            "",
-            self._make_forecast_section(forecasts),
-            "",
-        ]
-        report_content = "\n".join(md_lines)
+
+    def produce_report(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        report_content = self._build_report(payload)
         report_file = self.report_dir / "report.md"
         report_file.write_text(report_content, encoding="utf-8")
-        return {"report_file": str(report_file)}
-    def _make_detailed_section(self, metrics_list: list[HoldingMetrics]) -> str:
-        if not metrics_list:
-            return "No data available."
-        sections = []
-        for m in metrics_list:
-            section = [
-                f"
-                f"**Price**: ${m.current_price:.2f} | **YTD**: {m.ytd_return:.1%} | **12m**: {m.return_12m:.1%} | **Sharpe**: {m.sharpe_ratio:.2f}",
+        for key in ("manager_summary", "latest_holdings", "quarter_changes"):
+            value = payload.get(key)
+            if isinstance(value, pd.DataFrame):
+                value.to_parquet(self.report_dir / f"{key}.parquet", index=False)
+        return {"report_file": str(report_file), "report_content": report_content}
+
+    def _build_report(self, payload: Dict[str, Any]) -> str:
+        summary = _frame(payload, "manager_summary")
+        holdings = _frame(payload, "latest_holdings")
+        changes = _frame(payload, "quarter_changes", required=False)
+        if summary.empty or holdings.empty:
+            raise ValueError("Investor report requires canonical 13F holdings")
+
+        checked_on = datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y-%m-%d")
+        max_report_date = pd.to_datetime(summary["latest_report_date"]).max()
+        stale_days = (pd.Timestamp(checked_on) - max_report_date.normalize()).days
+        history_ready = bool(summary["comparison_ready"].all())
+        freshness_score = 4 if stale_days <= 135 else 2
+        history_score = 5 if history_ready else 2
+        total_score = freshness_score + 5 + 5 + history_score + 3
+
+        lines = [
+            "# 著名投資家13F差分監査",
+            "",
+            f"更新基準日: {checked_on}",
+            "",
+            "## 結論",
+            "",
+            "固定銘柄配列と現在保有という表現を廃止し、SEC 13F-HR information tableのアクセッション番号、報告対象日、CUSIP、株数、報告価額を正準入力にしました。最新四半期と前四半期の差分は提出後にのみ利用可能なポイント・イン・タイム情報として扱います。",
+            "",
+            "## データ",
+            "",
+            "### 提出主体",
+            "",
+            "| 提出主体 | 報告対象日 | 提出日 | 提出遅延 | ポジション数 | 履歴四半期 |",
+            "| --- | --- | --- | ---: | ---: | ---: |",
+        ]
+        for _, row in summary.sort_values("manager_display_name").iterrows():
+            lines.append(
+                f"| {row['manager_display_name']} | {pd.Timestamp(row['latest_report_date']).date()} | {pd.Timestamp(row['filing_date']).date()} | {int(row['filing_lag_days'])}日 | {int(row['position_count'])} | {int(row['history_quarters'])} |"
+            )
+
+        lines.extend(
+            [
                 "",
-                "
-                m.reason_why if m.reason_why else "N/A",
+                "### 最新上位保有",
                 "",
-                "
-                m.evaluation if m.evaluation else "N/A",
-                "",
-                "
-                m.rumor if m.rumor else "N/A",
-                "",
-                "
-                m.earnings if m.earnings else "N/A",
-                "",
-                "
-                m.alpha if m.alpha else "N/A",
-                "",
-                "
-                m.fundamentals if m.fundamentals else "No fundamental data.",
-                "",
-                "
-                m.news_summary if m.news_summary else "No recent news.",
-                "",
-                "---",
+                "| 提出主体 | 発行体 | クラス | CUSIP | Put/Call | 報告価額 | 構成比 | 株数・元本 |",
+                "| --- | --- | --- | --- | --- | ---: | ---: | ---: |",
             ]
-            sections.append("\n".join(section))
-        return "\n".join(sections)
-    def _make_forecast_section(self, forecasts: Dict[str, Any]) -> str:
-        if not forecasts:
-            return ""
-        lines = ["
-        for ticker, data in forecasts.items():
-            if isinstance(data, dict) and "error" in data:
-                lines.append(f"
-                continue
-            if not data:
-                continue
-            last = data[-1]
-            lines.append(f"
-            lines.append(f"- Prediction End: {last.get('date', 'N/A')}")
-            lines.append(f"- Predicted Close: {last.get('close', 'N/A'):.2f}")
-            lines.append("")
+        )
+        for _, row in holdings.sort_values(
+            ["manager_display_name", "reported_value"],
+            ascending=[True, False],
+        ).iterrows():
+            lines.append(
+                f"| {row['manager_display_name']} | {row['issuer']} | {row['title_of_class']} | `{row['cusip']}` | {row['put_call'] or '—'} | {_format_number(row['reported_value'])} | {_format_percent(row['portfolio_weight'])} | {_format_number(row['shares_or_principal'])} {row['shares_or_principal_type'] or ''} |"
+            )
+
+        lines.extend(
+            [
+                "",
+                "## 定量分析",
+                "",
+                "報告価額の変化には株価変化が含まれるため、売買方向は株数・元本の差分を優先します。新規、全売却、増加、減少、不変をCUSIP・クラス・Put/Call単位で分類します。",
+                "",
+            ]
+        )
+        if changes.empty:
+            lines.append("比較可能な前四半期information tableが不足しているため、売買差分は未評価です。")
+        else:
+            counts = (
+                changes.groupby(["manager_display_name", "change_type"])
+                .size()
+                .reset_index(name="positions")
+            )
+            lines.extend(
+                [
+                    "| 提出主体 | 変化 | ポジション数 |",
+                    "| --- | --- | ---: |",
+                ]
+            )
+            for _, row in counts.iterrows():
+                lines.append(
+                    f"| {row['manager_display_name']} | {row['change_type']} | {int(row['positions'])} |"
+                )
+            lines.extend(
+                [
+                    "",
+                    "価額変化の絶対値が大きい差分:",
+                    "",
+                    "| 提出主体 | 発行体 | CUSIP | 変化 | 株数差分 | 報告価額差分 |",
+                    "| --- | --- | --- | --- | ---: | ---: |",
+                ]
+            )
+            for _, row in changes.head(20).iterrows():
+                lines.append(
+                    f"| {row['manager_display_name']} | {row['issuer']} | `{row['cusip']}` | {row['change_type']} | {_format_signed(row['share_change'])} | {_format_signed(row['value_change'])} |"
+                )
+
+        lines.extend(
+            [
+                "",
+                "## 評価",
+                "",
+                "| 評価軸 | 点数 | 根拠 |",
+                "| --- | ---: | --- |",
+                f"| 開示鮮度 | {freshness_score}/5 | 最新報告対象日から{stale_days}日。13F固有の遅延を明示 |",
+                "| 一次資料 | 5/5 | SEC information table XMLを直接保存 |",
+                "| 保有再現性 | 5/5 | accession、CUSIP、株数、報告価額、raw hashを保持 |",
+                f"| 四半期差分 | {history_score}/5 | {'全主体で比較可能' if history_ready else '一部履歴不足'} |",
+                "| 解釈制約 | 3/5 | 現金・空売り・提出後変更は対象外 |",
+                f"| **合計** | **{total_score}/25** | **SEC 13F正準経路へ移行済み** |",
+                "",
+                "## 限界と反証条件",
+                "",
+                "- 13Fは四半期末時点の対象証券ロング保有であり、現在保有ではありません。",
+                "- 現金、空売り、非対象証券、四半期内売買、提出後変更を復元しません。",
+                "- 報告価額差分をそのまま売買額と呼びません。株価変化と企業行動が含まれます。",
+                "- 修正提出はアクセッション番号単位で保持し、元提出を消去しません。",
+                "- CUSIPからティッカーへの変換は正式な識別子マスターが整うまで推測しません。",
+                "",
+                "## 一次情報",
+                "",
+            ]
+        )
+        urls = set()
+        for key in ("holdings", "latest_holdings", "filings"):
+            value = payload.get(key)
+            if isinstance(value, pd.DataFrame):
+                for column in ("source_document_url", "_source_url"):
+                    if column in value.columns:
+                        urls.update(str(item) for item in value[column].dropna())
+        urls = urls or {
+            "https://data.sec.gov/submissions/CIK0001029160.json",
+            "https://data.sec.gov/submissions/CIK0001536411.json",
+        }
+        lines.extend(f"- {url}" for url in sorted(urls))
+        lines.append("")
         return "\n".join(lines)
+
+
+def _frame(payload: Dict[str, Any], key: str, *, required: bool = True) -> pd.DataFrame:
+    value = payload.get(key)
+    if isinstance(value, pd.DataFrame):
+        return value
+    if required:
+        raise TypeError(f"Expected DataFrame payload: {key}")
+    return pd.DataFrame()
+
+
+def _format_number(value: object) -> str:
+    if value is None or pd.isna(value):
+        return "—"
+    return f"{float(value):,.0f}"
+
+
+def _format_signed(value: object) -> str:
+    if value is None or pd.isna(value):
+        return "—"
+    return f"{float(value):+,.0f}"
+
+
+def _format_percent(value: object) -> str:
+    if value is None or pd.isna(value):
+        return "—"
+    return f"{float(value):.2%}"

--- a/crew/oracle/analysis.py
+++ b/crew/oracle/analysis.py
@@ -1,59 +1,157 @@
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
 from typing import Any, Dict
-from .config import OracleEarningsConfig
-from .models import ProjectedQuarter
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import yaml
+
+from crew.oracle.config import OracleEarningsConfig
+
+
 class OracleEarningsAnalyzer:
+    """Audit Oracle filings and XBRL facts without treating model scenarios as actuals."""
+
     def __init__(self, config: OracleEarningsConfig) -> None:
         self.config = config
-    def evaluate(self, data_payload: Dict[str, Any] = None) -> Dict[str, Any]:
-        config = self.config
-        base = config.base_quarter
-        results = {}
-        for scenario_name, scenario in config.projections.scenarios.items():
-            quarterly_data = []
-            cloud_rev = 7.0
-            other_rev = 9.1
-            seasonality = (
-                base.software_seasonality_factors
-                if base.software_seasonality_factors
-                else [1.0] * 4
+        self.raw_data_dir: Path | None = None
+
+    def evaluate(self, data_payload: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        payload = data_payload or {}
+        filings = self._load_frame(payload.get("filings"), "filings.parquet")
+        facts = self._load_frame(payload.get("facts"), "facts.parquet")
+
+        for column in ("filing_date", "report_date", "acceptance_datetime", "_retrieved_at"):
+            if column in filings.columns:
+                filings[column] = pd.to_datetime(filings[column])
+        for column in ("start_date", "end_date", "filed_date", "_retrieved_at"):
+            if column in facts.columns:
+                facts[column] = pd.to_datetime(facts[column])
+        facts["value"] = pd.to_numeric(facts["value"], errors="coerce")
+        facts = facts.dropna(subset=["value"])
+
+        filing_snapshot = (
+            filings.sort_values(
+                ["form", "filing_date", "acceptance_datetime"],
+                ascending=[True, False, False],
             )
-            normalized_software_runrate = other_rev / seasonality[1]
-            current_margin = base.operating_income_B / base.revenue_B
-            for i in range(1, config.projections.quarters_to_project + 1):
-                cloud_growth = (
-                    base.cloud_revenue_growth_yoy_pct
-                    * (scenario.cloud_growth_decay_rate**i)
-                    / 100.0
-                )
-                prev_cloud = cloud_rev
-                cloud_rev *= 1 + cloud_growth / 4
-                normalized_software_runrate *= (
-                    1 + (scenario.software_growth_rate * i) / 100.0 / 4
-                )
-                normalized_software_runrate -= (
-                    cloud_rev - prev_cloud
-                ) * base.cloud_cannibalization_ratio
-                software_rev = normalized_software_runrate * seasonality[(1 + i) % 4]
-                total_rev = cloud_rev + software_rev
-                current_margin += scenario.operating_margin_improvement / 100.0
-                target_intensity = scenario.capex_intensity_target
-                start_intensity = base.current_capex_intensity or 0.55
-                capex = total_rev * (
-                    start_intensity
-                    + (target_intensity - start_intensity)
-                    * (i / config.projections.quarters_to_project)
-                )
-                quarterly_data.append(
-                    ProjectedQuarter(
-                        quarter_index=i,
-                        period_label=f"FY{2026 + (2 + i - 1) // 4} Q{(2 + i - 1) % 4 + 1}",
-                        revenue_B=total_rev,
-                        operating_income_B=total_rev * current_margin,
-                        capex_B=capex,
-                        rpo_B=base.rpo_B
-                        * ((1 + scenario.rpo_growth_yoy) ** (0.25 * i)),
-                        fcf_B=(total_rev * current_margin) - capex,
-                    )
-                )
-            results[scenario_name] = quarterly_data
-        return {"projections": results, "base_quarter": base}
+            .groupby("form", as_index=False)
+            .head(1)
+            .reset_index(drop=True)
+        )
+        fact_snapshot = self._latest_facts(facts)
+        derived_fcf = self._derive_free_cash_flow(facts)
+        configured_metrics = set(self.config.concepts)
+        available_metrics = set(fact_snapshot.get("metric", pd.Series(dtype=str)))
+        coverage = pd.DataFrame(
+            [
+                {
+                    "configured_metrics": len(configured_metrics),
+                    "available_metrics": len(configured_metrics.intersection(available_metrics)),
+                    "coverage_ratio": (
+                        len(configured_metrics.intersection(available_metrics))
+                        / len(configured_metrics)
+                        if configured_metrics
+                        else 1.0
+                    ),
+                    "model_projection_enabled": self.config.allow_model_projection,
+                }
+            ]
+        )
+        return {
+            "filings": filings,
+            "facts": facts,
+            "filing_snapshot": filing_snapshot,
+            "fact_snapshot": fact_snapshot,
+            "derived_fcf": derived_fcf,
+            "coverage": coverage,
+            "projections": {},
+        }
+
+    def _load_frame(self, value: object, filename: str) -> pd.DataFrame:
+        if isinstance(value, pd.DataFrame):
+            return value.copy()
+        if isinstance(value, (str, Path)) and Path(value).is_file():
+            return pd.read_parquet(value)
+        if self.raw_data_dir is not None:
+            path = self.raw_data_dir / filename
+            if path.is_file():
+                return pd.read_parquet(path)
+        raise FileNotFoundError(
+            f"Canonical Oracle export {filename} is missing. Run `task fetch:oracle`."
+        )
+
+    @staticmethod
+    def _latest_facts(facts: pd.DataFrame) -> pd.DataFrame:
+        if facts.empty:
+            return facts
+        ordering = ["metric", "end_date", "filed_date", "_retrieved_at"]
+        available_ordering = [column for column in ordering if column in facts.columns]
+        sorted_facts = facts.sort_values(
+            available_ordering,
+            ascending=[True] + [False] * (len(available_ordering) - 1),
+            na_position="last",
+        )
+        group_columns = ["metric", "unit"] if "unit" in facts.columns else ["metric"]
+        return (
+            sorted_facts.groupby(group_columns, as_index=False, dropna=False)
+            .head(1)
+            .reset_index(drop=True)
+        )
+
+    @staticmethod
+    def _derive_free_cash_flow(facts: pd.DataFrame) -> pd.DataFrame:
+        required = {"operating_cash_flow", "capital_expenditure"}
+        if "metric" not in facts.columns or not required.issubset(set(facts["metric"])):
+            return pd.DataFrame(
+                columns=[
+                    "start_date",
+                    "end_date",
+                    "filed_date",
+                    "unit",
+                    "operating_cash_flow",
+                    "capital_expenditure",
+                    "derived_free_cash_flow",
+                ]
+            )
+        subset = facts[facts["metric"].isin(required)].copy()
+        keys = ["start_date", "end_date", "filed_date", "unit"]
+        pivot = subset.pivot_table(
+            index=keys,
+            columns="metric",
+            values="value",
+            aggfunc="last",
+        ).reset_index()
+        pivot = pivot.dropna(subset=list(required))
+        pivot["derived_free_cash_flow"] = (
+            pivot["operating_cash_flow"] - pivot["capital_expenditure"].abs()
+        )
+        return pivot.sort_values(["end_date", "filed_date"], ascending=False)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+CONFIG_FILE = PROJECT_ROOT / "config" / "use_cases" / "oracle.yaml"
+DATA_DIR = PROJECT_ROOT / "data" / "oracle"
+
+
+def main() -> None:
+    from crew.oracle.reporting import OracleEarningsReporter
+
+    config = OracleEarningsConfig(
+        **yaml.safe_load(CONFIG_FILE.read_text(encoding="utf-8"))
+    )
+    analyzer = OracleEarningsAnalyzer(config)
+    analyzer.raw_data_dir = DATA_DIR
+    result = analyzer.evaluate({})
+    report_date = datetime.datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y%m%d")
+    reporter = OracleEarningsReporter(
+        PROJECT_ROOT / "output" / "use_cases" / "oracle" / report_date
+    )
+    stored = reporter.produce_report(result)
+    print(f"Canonical Oracle report: {stored['report_file']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crew/oracle/config.py
+++ b/crew/oracle/config.py
@@ -1,5 +1,24 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from pydantic import Field
+
 from crew.base import UseCaseConfig
-from .models import FinancialParams, Projections
+
+
 class OracleEarningsConfig(UseCaseConfig):
-    base_quarter: FinancialParams
-    projections: Projections
+    entity_name: str = Field(default="oracle")
+    forms: List[str] = Field(default_factory=lambda: ["10-K", "10-Q", "8-K"])
+    concepts: Dict[str, List[str]] = Field(default_factory=dict)
+    allow_model_projection: bool = Field(default=False)
+
+    @property
+    def requested_concepts(self) -> list[str]:
+        return list(
+            dict.fromkeys(
+                concept
+                for candidates in self.concepts.values()
+                for concept in candidates
+            )
+        )

--- a/crew/oracle/data_pipeline.py
+++ b/crew/oracle/data_pipeline.py
@@ -1,20 +1,72 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Dict
+
+import pandas as pd
+
 from crew.app import BaseDataPipeline, GenericUseCase
-from crew.oracle.analysis import OracleEarningsAnalyzer
+from crew.data_platform.consumer import sec_company_facts, sec_filings
 from crew.oracle.config import OracleEarningsConfig
+
+
 class OracleDataPipeline(BaseDataPipeline):
+    """Export Oracle filings and selected XBRL facts from canonical SEC storage."""
+
+    def __init__(self, raw_data_dir: Path, config: OracleEarningsConfig) -> None:
+        super().__init__(raw_data_dir, config)
+
     def fetch_data_internal(self, targets: Dict[str, str], days: int) -> Dict[str, str]:
-        return {}
+        filings = sec_filings(
+            entity_names=[self.config.entity_name], forms=self.config.forms
+        )
+        all_facts = sec_company_facts(entity_name=self.config.entity_name)
+        selected: list[pd.DataFrame] = []
+        for metric, candidates in self.config.concepts.items():
+            matched = all_facts[all_facts["concept"].isin(candidates)].copy()
+            if matched.empty:
+                continue
+            matched["metric"] = metric
+            selected.append(matched)
+        if selected:
+            facts = pd.concat(selected, ignore_index=True)
+        else:
+            pattern = (
+                "Revenue|OperatingIncome|CashProvided|PropertyPlant|"
+                "ProductiveAssets|PerformanceObligation"
+            )
+            facts = all_facts[
+                all_facts["concept"].str.contains(pattern, case=False, na=False)
+            ].copy()
+            facts["metric"] = "unmapped"
+        if facts.empty:
+            raise ValueError("No decision-relevant Oracle SEC facts were found")
+
+        self._save("filings", filings)
+        self._save("facts", facts)
+        return {
+            "filings": str(self.raw_data_dir / "filings.parquet"),
+            "facts": str(self.raw_data_dir / "facts.parquet"),
+        }
+
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 CONFIG_FILE = PROJECT_ROOT / "config" / "use_cases" / "oracle.yaml"
+
+
 def main() -> None:
+    from crew.oracle.analysis import OracleEarningsAnalyzer
+
     use_case = GenericUseCase(
         config_path=CONFIG_FILE,
         pipeline_class=OracleDataPipeline,
         analyzer_class=OracleEarningsAnalyzer,
         config_class=OracleEarningsConfig,
     )
-    use_case.fetch_data()
+    saved_files = use_case.fetch_data()
+    for name, path in saved_files.items():
+        print(f"Saved canonical Oracle {name}: {path}")
+
+
 if __name__ == "__main__":
     main()

--- a/crew/oracle/reporting.py
+++ b/crew/oracle/reporting.py
@@ -1,35 +1,191 @@
+from __future__ import annotations
+
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List
-from .models import FinancialParams, ProjectedQuarter
+from typing import Any, Dict
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+
+
+_METRIC_LABELS = {
+    "revenue": "売上高",
+    "operating_income": "営業利益",
+    "operating_cash_flow": "営業キャッシュフロー",
+    "capital_expenditure": "設備投資",
+    "free_cash_flow": "会社開示FCF",
+    "remaining_performance_obligation": "残存履行義務",
+    "unmapped": "未マッピングSEC fact",
+}
+
+
 class OracleEarningsReporter:
-    def __init__(self, report_dir: Path):
+    def __init__(self, report_dir: Path) -> None:
         self.report_dir = report_dir
         self.report_dir.mkdir(parents=True, exist_ok=True)
-    def produce_report(self, analysis_payload: Dict[str, Any]) -> Dict[str, Any]:
-        projections = analysis_payload["projections"]
-        base: FinancialParams = analysis_payload["base_quarter"]
-        report = "
-        report += "
-        report += "These figures are based on FY2026 Q2 actuals provided.\n\n"
-        report += f"- **Period:** {base.period}\n"
-        report += f"- **Revenue:** ${base.revenue_B}B\n"
-        report += f"- **Operating Income:** ${base.operating_income_B}B (Margin: {base.operating_income_B / base.revenue_B:.1%})\n"
-        report += f"- **CAPEX (TTM):** ${base.capex_last_4q_B}B (Intensity: ~{base.current_capex_intensity:.1%})\n"
-        report += f"- **Cloud Growth:** {base.cloud_revenue_growth_yoy_pct}% YoY\n"
-        report += f"- **RPO:** ${base.rpo_B}B\n\n"
-        report += "
-        for scenario_name, quarters in projections.items():
-            quarters: List[ProjectedQuarter] = quarters
-            report += f"
-            report += "**Projections:**\n"
-            report += "| Period | Revenue ($B) | Op Ex ($B) | Op Inc ($B) | Margin | CAPEX ($B) | RPO ($B) |\n"
-            report += "|---|---|---|---|---|---|---|\n"
-            for q in quarters:
-                op_ex = q.revenue_B - q.operating_income_B
-                margin = q.operating_income_B / q.revenue_B
-                report += f"| {q.period_label} | {q.revenue_B:.2f} | {op_ex:.2f} | {q.operating_income_B:.2f} | {margin:.1%} | {q.capex_B:.2f} | {q.rpo_B:.1f} |\n"
-            report += "\n"
-        output_path = self.report_dir / "oracle_earnings_report.md"
-        with open(output_path, "w") as f:
-            f.write(report)
+
+    def produce_report(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        report = self._build_report(payload)
+        output_path = self.report_dir / "report.md"
+        output_path.write_text(report, encoding="utf-8")
+        for key in ("filing_snapshot", "fact_snapshot", "derived_fcf", "coverage"):
+            value = payload.get(key)
+            if isinstance(value, pd.DataFrame):
+                value.to_parquet(self.report_dir / f"{key}.parquet", index=False)
         return {"report_content": report, "report_file": str(output_path)}
+
+    def _build_report(self, payload: Dict[str, Any]) -> str:
+        filings = _frame(payload, "filing_snapshot")
+        facts = _frame(payload, "fact_snapshot")
+        derived_fcf = _frame(payload, "derived_fcf", required=False)
+        coverage = _frame(payload, "coverage")
+        if filings.empty or facts.empty:
+            raise ValueError("Oracle report requires SEC filing and fact snapshots")
+
+        checked_on = datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y-%m-%d")
+        latest_filing = pd.to_datetime(filings["filing_date"]).max()
+        latest_fact_filed = pd.to_datetime(facts["filed_date"]).max()
+        coverage_ratio = float(coverage.iloc[0]["coverage_ratio"])
+        projection_enabled = bool(coverage.iloc[0]["model_projection_enabled"])
+        freshness_days = (pd.Timestamp(checked_on) - latest_filing.normalize()).days
+        freshness_score = 5 if freshness_days <= 45 else 4 if freshness_days <= 90 else 2
+        coverage_score = 5 if coverage_ratio >= 0.8 else 3 if coverage_ratio >= 0.5 else 1
+        total_score = freshness_score + 5 + coverage_score + 4 + 4
+
+        lines = [
+            "# Oracle実績・設備投資回収監査",
+            "",
+            f"更新基準日: {checked_on}",
+            "",
+            "## 結論",
+            "",
+            "Oracle分析の実績入力を静的YAMLからSEC EDGAR提出履歴とXBRL Company Factsへ切り替えました。モデル予測は既定で停止し、会社実績、提出日時、報告期間、独自導出値を分離します。",
+            "",
+            "## データ",
+            "",
+            f"最新の対象提出日は **{latest_filing.date()}**、最新factの提出日は **{latest_fact_filed.date()}** です。",
+            "",
+            "### 最新提出書類",
+            "",
+            "| Form | 提出日 | 報告対象日 | アクセッション番号 |",
+            "| --- | --- | --- | --- |",
+        ]
+        for _, row in filings.sort_values("form").iterrows():
+            report_date = (
+                pd.Timestamp(row["report_date"]).date()
+                if not pd.isna(row["report_date"])
+                else "—"
+            )
+            lines.append(
+                f"| {row['form']} | {pd.Timestamp(row['filing_date']).date()} | {report_date} | `{row['accession_number']}` |"
+            )
+
+        lines.extend(
+            [
+                "",
+                "### 最新XBRL facts",
+                "",
+                "| 指標 | Concept | 期間末 | Form | 単位 | 値 |",
+                "| --- | --- | --- | --- | --- | ---: |",
+            ]
+        )
+        for _, row in facts.sort_values(["metric", "concept"]).iterrows():
+            end_date = (
+                pd.Timestamp(row["end_date"]).date()
+                if not pd.isna(row["end_date"])
+                else "—"
+            )
+            lines.append(
+                f"| {_METRIC_LABELS.get(str(row['metric']), row['metric'])} | `{row['concept']}` | {end_date} | {row['form']} | {row['unit']} | {_format_value(row['value'], row['unit'])} |"
+            )
+
+        lines.extend(
+            [
+                "",
+                "## 定量分析",
+                "",
+                f"設定した重要指標のXBRL充足率は **{coverage_ratio:.0%}** です。Company Factsの同一conceptでも四半期、累計、通期、単位、修正提出が異なるため、期間末と提出日を固定して比較します。",
+                "",
+            ]
+        )
+        if derived_fcf.empty:
+            lines.append(
+                "営業キャッシュフローと設備投資の同一期間factが揃わないため、独自FCFを生成していません。"
+            )
+        else:
+            latest = derived_fcf.iloc[0]
+            lines.extend(
+                [
+                    "同一期間の営業キャッシュフローと設備投資から導出した参考FCF:",
+                    "",
+                    "| 期間末 | 営業CF | 設備投資 | 導出FCF | 単位 |",
+                    "| --- | ---: | ---: | ---: | --- |",
+                    f"| {pd.Timestamp(latest['end_date']).date()} | {_format_value(latest['operating_cash_flow'], latest['unit'])} | {_format_value(latest['capital_expenditure'], latest['unit'])} | {_format_value(latest['derived_free_cash_flow'], latest['unit'])} | {latest['unit']} |",
+                    "",
+                    "このFCFはSEC factsからの独自導出値であり、Oracleが定義・公表した指標とは区別します。",
+                ]
+            )
+
+        lines.extend(
+            [
+                "",
+                "## 評価",
+                "",
+                "| 評価軸 | 点数 | 根拠 |",
+                "| --- | ---: | --- |",
+                f"| 開示鮮度 | {freshness_score}/5 | 最新提出から{freshness_days}日 |",
+                "| 一次資料 | 5/5 | SEC accessionとCompany Factsを直接使用 |",
+                f"| 指標充足 | {coverage_score}/5 | 設定指標の{coverage_ratio:.0%}を取得 |",
+                "| 時点管理 | 4/5 | 報告期間、提出日、取得時刻、raw hashを保持 |",
+                "| 予測分離 | 4/5 | モデル予測を既定停止し実績と分離 |",
+                f"| **合計** | **{total_score}/25** | **SEC正準経路へ移行済み** |",
+                "",
+                "## 限界と反証条件",
+                "",
+                "- SEC Company Factsは会社IR資料の全ての非GAAP指標やクラウド区分を含みません。",
+                "- RPOの会社固有conceptが取得できない場合、推測値で補完しません。",
+                "- 四半期値と年初来累計値を期間調整せず比較しません。",
+                "- 修正提出があれば旧factを上書きせず、アクセッション番号単位で保持します。",
+                f"- モデル予測は現在 **{'有効' if projection_enabled else '停止'}** であり、実績として表示しません。",
+                "",
+                "## 一次情報",
+                "",
+            ]
+        )
+        urls = _source_urls(payload)
+        lines.extend(f"- {url}" for url in urls)
+        lines.append("")
+        return "\n".join(lines)
+
+
+def _frame(payload: Dict[str, Any], key: str, *, required: bool = True) -> pd.DataFrame:
+    value = payload.get(key)
+    if isinstance(value, pd.DataFrame):
+        return value
+    if required:
+        raise TypeError(f"Expected DataFrame payload: {key}")
+    return pd.DataFrame()
+
+
+def _format_value(value: object, unit: object) -> str:
+    numeric = float(value)
+    unit_text = str(unit)
+    if unit_text == "USD":
+        magnitude = abs(numeric)
+        if magnitude >= 1_000_000_000:
+            return f"${numeric / 1_000_000_000:,.2f}B"
+        if magnitude >= 1_000_000:
+            return f"${numeric / 1_000_000:,.2f}M"
+    return f"{numeric:,.2f}"
+
+
+def _source_urls(payload: Dict[str, Any]) -> list[str]:
+    urls: set[str] = set()
+    for key in ("filings", "facts", "filing_snapshot", "fact_snapshot"):
+        value = payload.get(key)
+        if isinstance(value, pd.DataFrame) and "_source_url" in value.columns:
+            urls.update(str(item) for item in value["_source_url"].dropna())
+    return sorted(urls) or [
+        "https://data.sec.gov/submissions/CIK0001341439.json",
+        "https://data.sec.gov/api/xbrl/companyfacts/CIK0001341439.json",
+    ]

--- a/crew/yields/analysis.py
+++ b/crew/yields/analysis.py
@@ -1,224 +1,215 @@
 from __future__ import annotations
+
+import datetime
+from pathlib import Path
 from typing import Dict, List
+from zoneinfo import ZoneInfo
+
+import numpy as np
 import pandas as pd
-from crew.yields.allocation import compute_allocation
+import yaml
+
 from crew.yields.config import YieldSpreadConfig
+
+
 class YieldSpreadAnalyzer:
+    """Analyze official Treasury rates without mixing credit and duration proxies."""
+
     def __init__(self, config: YieldSpreadConfig) -> None:
         self.config = config
-    def evaluate(
-        self, data_payload: Dict[str, pd.DataFrame]
-    ) -> Dict[str, pd.DataFrame]:
-        if "series" not in data_payload or isinstance(data_payload.get("series"), str):
-            p = self.raw_data_dir / "series.parquet"
-            if p.exists():
-                data_payload["series"] = pd.read_parquet(p)
-            else:
-                series_path = self.raw_data_dir / "series.csv"
-                if series_path.exists():
-                    data_payload["series"] = pd.read_csv(
-                        series_path, index_col=0, parse_dates=True
-                    )
-                else:
-                    data_payload["series"] = pd.DataFrame()
-        if "asset_prices" not in data_payload or isinstance(
-            data_payload.get("asset_prices"), str
-        ):
-            p = self.raw_data_dir / "asset_prices.parquet"
-            if p.exists():
-                data_payload["asset_prices"] = pd.read_parquet(p)
-            else:
-                prices_path = self.raw_data_dir / "asset_prices.csv"
-                if prices_path.exists():
-                    data_payload["asset_prices"] = pd.read_csv(
-                        prices_path, index_col=0, parse_dates=True
-                    )
-        series_frame = data_payload["series"]
-        asset_prices = data_payload.get("asset_prices")
-        metrics = self._compute_pair_metrics(series_frame)
-        edges = self._detect_edges(metrics)
-        snapshot = self._build_snapshot(metrics)
-        payload = {
-            "series": series_frame,
+        self.raw_data_dir: Path | None = None
+
+    def evaluate(self, data_payload: Dict[str, object]) -> Dict[str, pd.DataFrame]:
+        rates = self._load_frame(data_payload.get("rates"), "rates.parquet")
+        curve = self._load_frame(
+            data_payload.get("treasury_curve"), "treasury_curve.parquet"
+        )
+        provenance = self._load_frame(
+            data_payload.get("rates_provenance"),
+            "rates_provenance.parquet",
+            required=False,
+        )
+
+        if "Date" in rates.columns:
+            rates["Date"] = pd.to_datetime(rates["Date"])
+            rates = rates.set_index("Date")
+        rates.index = pd.to_datetime(rates.index)
+        rates = rates.sort_index().apply(pd.to_numeric, errors="coerce")
+        curve["observation_date"] = pd.to_datetime(curve["observation_date"])
+        curve["value"] = pd.to_numeric(curve["value"], errors="coerce")
+
+        metrics = self._compute_spreads(rates)
+        signals = self._detect_signals(metrics)
+        spread_snapshot = self._spread_snapshot(metrics)
+        macro_snapshot = self._macro_snapshot(rates)
+        curve_snapshot = self._curve_snapshot(curve)
+        return {
+            "rates": rates,
+            "treasury_curve": curve,
             "metrics": metrics,
-            "edges": edges,
-            "snapshot": snapshot,
+            "signals": signals,
+            "spread_snapshot": spread_snapshot,
+            "macro_snapshot": macro_snapshot,
+            "curve_snapshot": curve_snapshot,
+            "provenance": provenance,
         }
-        if asset_prices is not None:
-            payload["asset_prices"] = asset_prices
-        allocation = None
-        if self.config.allocation is not None:
-            allocation = compute_allocation(
-                self.config.allocation, snapshot, asset_prices
+
+    def _load_frame(
+        self, value: object, filename: str, *, required: bool = True
+    ) -> pd.DataFrame:
+        if isinstance(value, pd.DataFrame):
+            return value.copy()
+        if isinstance(value, (str, Path)) and Path(value).is_file():
+            return pd.read_parquet(value)
+        if self.raw_data_dir is not None:
+            path = self.raw_data_dir / filename
+            if path.is_file():
+                return pd.read_parquet(path)
+        if required:
+            raise FileNotFoundError(
+                f"Canonical export {filename} is missing. Run `task fetch:yield`."
             )
-        if allocation is not None:
-            payload["allocation"] = allocation
-        return payload
-    def _compute_pair_metrics(self, series_frame: pd.DataFrame) -> pd.DataFrame:
-        metrics_store: Dict[str, pd.DataFrame] = {}
-        for label, pair in self.config.pairs.items():
-            junk_series = series_frame[pair.junk.identifier]
-            treasury_series = series_frame[pair.treasury.identifier]
-            spread = junk_series - treasury_series
-            spread_bp = spread * 100
-            rolling_mean = spread.rolling(
-                window=self.config.rolling_window,
+        return pd.DataFrame()
+
+    def _compute_spreads(self, rates: pd.DataFrame) -> pd.DataFrame:
+        store: Dict[str, pd.DataFrame] = {}
+        for label, definition in self.config.curve_spreads.items():
+            missing = sorted(
+                {definition.short_label, definition.long_label}.difference(
+                    rates.columns
+                )
+            )
+            if missing:
+                raise ValueError(f"Missing canonical rate series for {label}: {missing}")
+            aligned = rates[
+                [definition.short_label, definition.long_label]
+            ].dropna()
+            spread_pct = (
+                aligned[definition.long_label] - aligned[definition.short_label]
+            )
+            rolling_mean = spread_pct.rolling(
+                self.config.rolling_window,
                 min_periods=self.config.minimum_periods,
             ).mean()
-            rolling_std = spread.rolling(
-                window=self.config.rolling_window,
+            rolling_std = spread_pct.rolling(
+                self.config.rolling_window,
                 min_periods=self.config.minimum_periods,
-            ).std()
-            rolling_std = rolling_std.replace(0, pd.NA)
-            z_score = (spread - rolling_mean) / rolling_std
-            metrics_store[label] = pd.DataFrame(
+            ).std().replace(0, np.nan)
+            store[label] = pd.DataFrame(
                 {
-                    "junk_yield": junk_series,
-                    "treasury_yield": treasury_series,
-                    "spread": spread,
-                    "spread_bp": spread_bp,
-                    "rolling_mean": rolling_mean,
-                    "rolling_std": rolling_std,
-                    "z_score": z_score,
+                    "short_rate_pct": aligned[definition.short_label],
+                    "long_rate_pct": aligned[definition.long_label],
+                    "spread_pct": spread_pct,
+                    "spread_bp": spread_pct * 100.0,
+                    "change_20d_bp": spread_pct.diff(20) * 100.0,
+                    "rolling_mean_pct": rolling_mean,
+                    "rolling_std_pct": rolling_std,
+                    "z_score": (spread_pct - rolling_mean) / rolling_std,
                 }
             )
-        metrics_frame = pd.concat(metrics_store, axis=1)
-        return metrics_frame
-    def _detect_edges(self, metrics_frame: pd.DataFrame) -> pd.DataFrame:
-        records: List[Dict[str, object]] = []
-        for label, pair in self.config.pairs.items():
-            pair_frame = metrics_frame[label].dropna(subset=["z_score"])
-            if pair_frame.empty:
-                continue
-            z_mask = pair_frame["z_score"].abs() >= self.config.z_score_threshold
+        return pd.concat(store, axis=1).sort_index()
+
+    def _detect_signals(self, metrics: pd.DataFrame) -> pd.DataFrame:
+        records: List[dict[str, object]] = []
+        for label in self.config.curve_spreads:
+            frame = metrics[label].dropna(subset=["z_score"])
+            mask = frame["z_score"].abs() >= self.config.z_score_threshold
             if self.config.bp_alert_threshold > 0:
-                bp_mask = (
-                    pair_frame["spread_bp"].abs() >= self.config.bp_alert_threshold
-                )
-                mask = z_mask & bp_mask
-            else:
-                mask = z_mask
-            filtered = pair_frame.loc[mask]
-            for timestamp, row in filtered.iterrows():
-                direction = "widening" if row["z_score"] >= 0 else "tightening"
+                mask &= frame["change_20d_bp"].abs() >= self.config.bp_alert_threshold
+            for timestamp, row in frame.loc[mask].iterrows():
                 records.append(
                     {
                         "date": timestamp,
-                        "pair": label,
-                        "junk_identifier": pair.junk.identifier,
-                        "treasury_identifier": pair.treasury.identifier,
-                        "spread_bp": row["spread_bp"],
-                        "spread": row["spread"],
-                        "z_score": row["z_score"],
-                        "junk_yield": row["junk_yield"],
-                        "treasury_yield": row["treasury_yield"],
-                        "direction": direction,
-                        "description": pair.description or "",
+                        "spread": label,
+                        "spread_bp": float(row["spread_bp"]),
+                        "change_20d_bp": float(row["change_20d_bp"]),
+                        "z_score": float(row["z_score"]),
+                        "direction": "steepening"
+                        if row["change_20d_bp"] > 0
+                        else "flattening",
                     }
                 )
-        if not records:
-            return pd.DataFrame(
-                columns=[
-                    "date",
-                    "pair",
-                    "junk_identifier",
-                    "treasury_identifier",
-                    "spread_bp",
-                    "spread",
-                    "z_score",
-                    "junk_yield",
-                    "treasury_yield",
-                    "direction",
-                    "description",
-                ]
-            )
-        edges_frame = pd.DataFrame.from_records(records)
-        edges_frame = edges_frame.sort_values("date")
-        return edges_frame
-    def _build_snapshot(self, metrics_frame: pd.DataFrame) -> pd.DataFrame:
-        rows: List[Dict[str, object]] = []
-        for label, pair in self.config.pairs.items():
-            pair_frame = metrics_frame[label].dropna(subset=["spread"])
-            if pair_frame.empty:
+        columns = [
+            "date",
+            "spread",
+            "spread_bp",
+            "change_20d_bp",
+            "z_score",
+            "direction",
+        ]
+        return pd.DataFrame.from_records(records, columns=columns).sort_values(
+            "date", ignore_index=True
+        ) if records else pd.DataFrame(columns=columns)
+
+    def _spread_snapshot(self, metrics: pd.DataFrame) -> pd.DataFrame:
+        rows: List[dict[str, object]] = []
+        for label, definition in self.config.curve_spreads.items():
+            frame = metrics[label].dropna(subset=["spread_pct"])
+            if frame.empty:
                 continue
-            last_row = pair_frame.iloc[-1]
+            row = frame.iloc[-1]
             rows.append(
                 {
-                    "pair": label,
-                    "latest_date": pair_frame.index[-1],
-                    "spread_bp": last_row["spread_bp"],
-                    "spread": last_row["spread"],
-                    "z_score": last_row["z_score"],
-                    "junk_yield": last_row["junk_yield"],
-                    "treasury_yield": last_row["treasury_yield"],
+                    "spread": label,
+                    "description": definition.description or "",
+                    "latest_date": frame.index[-1],
+                    "short_rate_pct": float(row["short_rate_pct"]),
+                    "long_rate_pct": float(row["long_rate_pct"]),
+                    "spread_bp": float(row["spread_bp"]),
+                    "change_20d_bp": _optional_float(row["change_20d_bp"]),
+                    "z_score": _optional_float(row["z_score"]),
                 }
             )
-        if not rows:
-            return pd.DataFrame(
-                columns=[
-                    "pair",
-                    "latest_date",
-                    "spread_bp",
-                    "spread",
-                    "z_score",
-                    "junk_yield",
-                    "treasury_yield",
-                ]
+        return pd.DataFrame(rows)
+
+    @staticmethod
+    def _macro_snapshot(rates: pd.DataFrame) -> pd.DataFrame:
+        rows: List[dict[str, object]] = []
+        for label in rates.columns:
+            series = rates[label].dropna()
+            if series.empty:
+                continue
+            rows.append(
+                {
+                    "series": label,
+                    "latest_date": series.index[-1],
+                    "value_pct": float(series.iloc[-1]),
+                }
             )
         return pd.DataFrame(rows)
-if __name__ == "__main__":
-    import yaml
-    from pathlib import Path
-    import datetime
-    from crew.yields.config import YieldSpreadConfig
+
+    @staticmethod
+    def _curve_snapshot(curve: pd.DataFrame) -> pd.DataFrame:
+        if curve.empty:
+            return curve
+        latest_date = curve["observation_date"].max()
+        return curve[curve["observation_date"] == latest_date].sort_values("tenor")
+
+
+def _optional_float(value: object) -> float | None:
+    return None if pd.isna(value) else float(value)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+CONFIG_FILE = PROJECT_ROOT / "config" / "use_cases" / "yields.yaml"
+DATA_DIR = PROJECT_ROOT / "data" / "yields"
+
+
+def main() -> None:
     from crew.yields.reporting import YieldSpreadReporter
-    from crew.utils.kronos_utils import get_kronos_forecast
-    PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-    CONFIG_FILE = PROJECT_ROOT / "config" / "use_cases" / "yields.yaml"
-    DATA_DIR = PROJECT_ROOT / "data" / "yields"
-    today = datetime.date.today().strftime("%Y%m%d")
-    REPORT_DIR = PROJECT_ROOT / "output" / "use_cases" / "yields" / today
-    with open(CONFIG_FILE, "r", encoding="utf-8") as f:
-        config_data = yaml.safe_load(f)
-    config = YieldSpreadConfig(**config_data)
+
+    config = YieldSpreadConfig(
+        **yaml.safe_load(CONFIG_FILE.read_text(encoding="utf-8"))
+    )
     analyzer = YieldSpreadAnalyzer(config)
     analyzer.raw_data_dir = DATA_DIR
-    analysis_payload = {}
-    results = analyzer.evaluate(analysis_payload)
-    forecasts = {}
-    metrics = results.get("metrics")
-    if isinstance(metrics, pd.DataFrame):
-        pairs = metrics.columns.levels[0]
-        for pair in pairs:
-            spread_series = metrics[pair]["spread"].dropna()
-            if len(spread_series) > 30:
-                df = spread_series.to_frame(name="close")
-                df["open"] = df["close"]
-                df["high"] = df["close"]
-                df["low"] = df["close"]
-                df["volume"] = 0.0
-                df = df.reset_index()
-                df.columns = ["date", "close", "open", "high", "low", "volume"]
-                df["Date"] = pd.to_datetime(df["date"])
-                try:
-                    x_timestamp = df["Date"]
-                    pred_len = 30
-                    last_date = df["Date"].iloc[-1]
-                    future_dates = [
-                        last_date + pd.Timedelta(days=i + 1) for i in range(pred_len)
-                    ]
-                    y_timestamp = pd.Series(future_dates)
-                    pred_df = get_kronos_forecast(
-                        df=df,
-                        x_timestamp=x_timestamp,
-                        y_timestamp=y_timestamp,
-                        pred_len=pred_len,
-                    )
-                    forecasts[pair] = pred_df.to_dict(orient="records")
-                except Exception as e:
-                    print(f"Kronos forecast failed for {pair}: {e}")
-                    forecasts[pair] = {"error": str(e)}
-    results["forecasts"] = forecasts
-    reporter = YieldSpreadReporter(config, DATA_DIR / "processed", REPORT_DIR)
-    reporter.persist(results)
-    print(f"Report produced in {REPORT_DIR}")
+    results = analyzer.evaluate({})
+    report_date = datetime.datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y%m%d")
+    report_dir = PROJECT_ROOT / "output" / "use_cases" / "yield_spread" / report_date
+    reporter = YieldSpreadReporter(config, DATA_DIR / "processed", report_dir)
+    stored = reporter.persist(results)
+    print(f"Canonical yield report: {stored['report']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crew/yields/config.py
+++ b/crew/yields/config.py
@@ -1,119 +1,55 @@
 from __future__ import annotations
-from typing import Dict, List, Literal
+
+from typing import Dict
+
 from pydantic import BaseModel, Field, validator
+
 from crew.base import UseCaseConfig
-class YieldSeriesConfig(BaseModel):
-    source: Literal["fred", "yfinance"]
-    identifier: str
-    scaling: float = Field(default=1.0)
-    field: str = Field(default="Close")
+
+
+class CurveSpreadConfig(BaseModel):
+    short_label: str
+    long_label: str
     description: str | None = None
-class YieldSpreadPair(BaseModel):
-    junk: YieldSeriesConfig
-    treasury: YieldSeriesConfig
-    description: str | None = None
-class AllocationProfile(BaseModel):
-    label: str
-    weights: Dict[str, float]
-    @validator("weights")
-    def _ensure_positive(cls, value: Dict[str, float]) -> Dict[str, float]:
-        if not value:
-            raise ValueError("weights must not be empty")
-        total = sum(value.values())
-        if total <= 0:
-            raise ValueError("weights must sum to a positive value")
-        return value
-class OptimizationConfig(BaseModel):
-    enabled: bool = Field(default=False)
-    lookback: str = Field(default="1y")
-    sample_size: int = Field(default=5000)
-    min_weight: float = Field(default=0.0)
-    max_weight: float = Field(default=1.0)
-    risk_free_rate: float = Field(default=0.0)
-    sensitivity_sample_sizes: List[int] = Field(
-        default_factory=lambda: [1000, 5000, 10000]
-    )
-    @validator("lookback")
-    def _validate_lookback(cls, value: str) -> str:
-        value = value.strip().lower()
-        if len(value) < 2 or value[-1] not in {"y", "m", "d"}:
-            raise ValueError(
-                "lookback must end with 'y', 'm', or 'd' (e.g., '1y', '6m')"
-            )
-        int(value[:-1])
-        return value
-class AllocationConfig(BaseModel):
-    upper_z: float = Field(
-        default=1.0, description="Threshold above which the regime is defensive."
-    )
-    lower_z: float = Field(
-        default=-1.0, description="Threshold below which the regime is risk-on."
-    )
-    widening: AllocationProfile = Field(
-        default_factory=lambda: AllocationProfile(
-            label="Defensive",
-            weights={"IEF": 0.5, "TLT": 0.3, "BIL": 0.2},
-        )
-    )
-    neutral: AllocationProfile = Field(
-        default_factory=lambda: AllocationProfile(
-            label="Neutral",
-            weights={"SPY": 0.5, "IEF": 0.3, "HYG": 0.2},
-        )
-    )
-    tightening: AllocationProfile = Field(
-        default_factory=lambda: AllocationProfile(
-            label="Risk-On",
-            weights={"SPY": 0.6, "QQQ": 0.2, "HYG": 0.2},
-        )
-    )
-    optimization: OptimizationConfig = Field(default_factory=OptimizationConfig)
-    @validator("upper_z")
-    def _check_upper(cls, value: float, values: Dict[str, float]) -> float:
-        lower = values.get("lower_z")
-        if lower is not None and value <= lower:
-            raise ValueError("upper_z must be greater than lower_z")
-        return value
+
+
 class YieldSpreadConfig(UseCaseConfig):
+    rates_dataset: str = Field(default="rates_macro")
+    curve_dataset: str = Field(default="treasury_par_yield_curve")
     period: str = Field(default="5y")
-    rolling_window: int = Field(default=60)
-    minimum_periods: int = Field(default=20)
-    z_score_threshold: float = Field(default=1.5)
-    bp_alert_threshold: float = Field(default=0.0)
-    allocation: AllocationConfig | None = Field(default_factory=AllocationConfig)
-    pairs: Dict[str, YieldSpreadPair] = Field(
+    rolling_window: int = Field(default=60, ge=2)
+    minimum_periods: int = Field(default=20, ge=2)
+    z_score_threshold: float = Field(default=1.5, gt=0)
+    bp_alert_threshold: float = Field(default=25.0, ge=0)
+    curve_spreads: Dict[str, CurveSpreadConfig] = Field(
         default_factory=lambda: {
-            "us_high_yield_vs_us10y": YieldSpreadPair(
-                junk=YieldSeriesConfig(
-                    source="fred",
-                    identifier="BAMLH0A0HYM2EY",
-                    description="ICE BofA US High Yield Index Effective Yield (%)",
-                ),
-                treasury=YieldSeriesConfig(
-                    source="fred",
-                    identifier="DGS10",
-                    field="value",
-                    description="US 10Y Treasury Constant Maturity Rate (%)",
-                ),
-                description="US High Yield minus 10Y Treasury yield spread",
-            )
+            "us_2s10s": CurveSpreadConfig(
+                short_label="us_2y",
+                long_label="us_10y",
+                description="US 10Y minus 2Y constant maturity rate",
+            ),
+            "us_10s30s": CurveSpreadConfig(
+                short_label="us_10y",
+                long_label="us_30y",
+                description="US 30Y minus 10Y constant maturity rate",
+            ),
         }
     )
+
     @validator("period")
     def _validate_period(cls, value: str) -> str:
-        value = value.strip().lower()
-        if len(value) < 2 or value[-1] not in {"y", "m", "d"}:
-            raise ValueError(
-                "period must end with 'y', 'm', or 'd' (e.g., '5y', '18m')"
-            )
-        int(value[:-1])
+        normalized = value.strip().lower()
+        if len(normalized) < 2 or normalized[-1] not in {"y", "m", "d"}:
+            raise ValueError("period must end with y, m, or d")
+        int(normalized[:-1])
+        return normalized
+
+    @validator("minimum_periods")
+    def _validate_minimum_periods(cls, value: int, values: dict) -> int:
+        rolling_window = values.get("rolling_window")
+        if rolling_window is not None and value > rolling_window:
+            raise ValueError("minimum_periods must not exceed rolling_window")
         return value
-    @property
-    def series_configs(self) -> Dict[str, YieldSeriesConfig]:
-        configs: Dict[str, YieldSeriesConfig] = {}
-        for pair in self.pairs.values():
-            for series in (pair.junk, pair.treasury):
-                key = f"{series.source}:{series.identifier}"
-                configs.setdefault(key, series)
-        return configs
+
+
 DEFAULT_CONFIG = YieldSpreadConfig(name="yield_spread")

--- a/crew/yields/data_pipeline.py
+++ b/crew/yields/data_pipeline.py
@@ -1,104 +1,81 @@
 from __future__ import annotations
-from datetime import datetime
+
 from pathlib import Path
 from typing import Dict
+
 import pandas as pd
+
 from crew.app import BaseDataPipeline
-from crew.clients import YieldSpreadDataClient
-from crew.clients.yield_spread import YieldSeriesRequest
-from crew.yields.asset_client import AllocationAssetClient
-from crew.yields.config import (
-    AllocationConfig,
-    YieldSeriesConfig,
-    YieldSpreadConfig,
+from crew.data_platform.consumer import (
+    latest_vintage_series,
+    pivot_latest_vintage,
+    treasury_curve,
 )
+from crew.yields.config import YieldSpreadConfig
+
+
 class YieldSpreadDataPipeline(BaseDataPipeline):
+    """Export official rate series and the Treasury curve from canonical storage."""
+
     def __init__(self, raw_data_dir: Path, config: YieldSpreadConfig) -> None:
         super().__init__(raw_data_dir, config)
-        self.client = YieldSpreadDataClient(raw_data_dir)
+
     def fetch_data_internal(self, targets: Dict[str, str], days: int) -> Dict[str, str]:
-        start_date = self._compute_start_date(self.config.period)
-        requests = self._build_requests(self.config.series_configs)
-        series_map = self.client.fetch_series(
-            requests.values(), start_date, self.config.period
-        )
-        frame = self._assemble_frame(series_map)
-        saved_files = {}
-        self._save("series", frame)
-        saved_files["series"] = str(self.raw_data_dir / "series.parquet")
-        allocation_cfg = self.config.allocation
-        if allocation_cfg is not None and allocation_cfg.optimization.enabled:
-            asset_prices = self._collect_allocation_prices(allocation_cfg)
-            if asset_prices is not None:
-                self._save("asset_prices", asset_prices)
-                saved_files["asset_prices"] = str(
-                    self.raw_data_dir / "asset_prices.parquet"
-                )
-        return saved_files
-    def _build_requests(
-        self, configs: Dict[str, YieldSeriesConfig]
-    ) -> Dict[str, YieldSeriesRequest]:
-        requests: Dict[str, YieldSeriesRequest] = {}
-        for key, cfg in configs.items():
-            requests[key] = YieldSeriesRequest(
-                source=cfg.source,
-                identifier=cfg.identifier,
-                scaling=cfg.scaling,
-                field=cfg.field,
-            )
-        return requests
-    def _assemble_frame(self, series_map: Dict[str, pd.Series]) -> pd.DataFrame:
-        series_list: Dict[str, pd.Series] = {}
-        for identifier, series in series_map.items():
-            if isinstance(series, pd.DataFrame):
-                if series.shape[1] != 1:
-                    raise ValueError(
-                        f"{identifier} returned unexpected columns: {list(series.columns)}"
-                    )
-                series = series.iloc[:, 0]
-            series = series.rename(identifier)
-            series_list[identifier] = series
-        frame = pd.concat(series_list.values(), axis=1)
-        frame.columns = list(series_list.keys())
-        frame = frame.sort_index()
-        frame = frame.ffill()
-        return frame
-    def _compute_start_date(self, period: str) -> datetime:
-        period = period.lower()
+        rates = pivot_latest_vintage(self.config.rates_dataset)
+        rates = self._slice_period(rates, self.config.period)
+        required_labels = {
+            label
+            for spread in self.config.curve_spreads.values()
+            for label in (spread.short_label, spread.long_label)
+        }
+        required_labels.update({"us_10y_real", "us_10y_breakeven"})
+        missing = sorted(required_labels.difference(rates.columns))
+        if missing:
+            raise ValueError(f"Canonical rate series are missing: {missing}")
+
+        provenance = latest_vintage_series(self.config.rates_dataset)
+        provenance = provenance[provenance["label"].isin(required_labels)].copy()
+        if not rates.empty:
+            provenance = provenance[
+                provenance["observation_date"] >= rates.index.min()
+            ]
+
+        curve = treasury_curve(latest_only=False)
+        self._save("rates", rates.reset_index())
+        self._save("rates_provenance", provenance)
+        self._save("treasury_curve", curve)
+        return {
+            "rates": str(self.raw_data_dir / "rates.parquet"),
+            "rates_provenance": str(
+                self.raw_data_dir / "rates_provenance.parquet"
+            ),
+            "treasury_curve": str(self.raw_data_dir / "treasury_curve.parquet"),
+        }
+
+    @staticmethod
+    def _slice_period(frame: pd.DataFrame, period: str) -> pd.DataFrame:
+        if frame.empty:
+            return frame
         value = int(period[:-1])
         unit = period[-1]
-        today = pd.Timestamp.today().normalize()
+        end = frame.index.max()
         if unit == "y":
-            start = today - pd.DateOffset(years=value)
+            start = end - pd.DateOffset(years=value)
         elif unit == "m":
-            start = today - pd.DateOffset(months=value)
+            start = end - pd.DateOffset(months=value)
         else:
-            start = today - pd.DateOffset(days=value)
-        return start.to_pydatetime()
-    def _collect_allocation_prices(
-        self, allocation_cfg: AllocationConfig
-    ) -> pd.DataFrame | None:
-        tickers: set[str] = set()
-        for profile in (
-            allocation_cfg.widening,
-            allocation_cfg.neutral,
-            allocation_cfg.tightening,
-        ):
-            tickers.update(profile.weights.keys())
-        if not tickers:
-            return None
-        client = AllocationAssetClient(self.raw_data_dir)
-        period = allocation_cfg.optimization.lookback
-        try:
-            prices = client.get_prices(sorted(tickers), period)
-        except Exception:
-            return None
-        return prices
+            start = end - pd.Timedelta(days=value)
+        return frame.loc[start:end]
+
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 CONFIG_FILE = PROJECT_ROOT / "config" / "use_cases" / "yields.yaml"
+
+
 def main() -> None:
     from crew.app import GenericUseCase
     from crew.yields.analysis import YieldSpreadAnalyzer
+
     use_case = GenericUseCase(
         config_path=CONFIG_FILE,
         pipeline_class=YieldSpreadDataPipeline,
@@ -107,65 +84,8 @@ def main() -> None:
     )
     saved_files = use_case.fetch_data()
     for name, path in saved_files.items():
-        print(f"Saved {name}: {path}")
+        print(f"Saved canonical {name}: {path}")
+
+
 if __name__ == "__main__":
     main()
-    def _build_requests(
-        self, configs: Dict[str, YieldSeriesConfig]
-    ) -> Dict[str, YieldSeriesRequest]:
-        requests: Dict[str, YieldSeriesRequest] = {}
-        for key, cfg in configs.items():
-            requests[key] = YieldSeriesRequest(
-                source=cfg.source,
-                identifier=cfg.identifier,
-                scaling=cfg.scaling,
-                field=cfg.field,
-            )
-        return requests
-    def _assemble_frame(self, series_map: Dict[str, pd.Series]) -> pd.DataFrame:
-        series_list: Dict[str, pd.Series] = {}
-        for identifier, series in series_map.items():
-            if isinstance(series, pd.DataFrame):
-                if series.shape[1] != 1:
-                    raise ValueError(
-                        f"{identifier} returned unexpected columns: {list(series.columns)}"
-                    )
-                series = series.iloc[:, 0]
-            series = series.rename(identifier)
-            series_list[identifier] = series
-        frame = pd.concat(series_list.values(), axis=1)
-        frame.columns = list(series_list.keys())
-        frame = frame.sort_index()
-        frame = frame.ffill()
-        return frame
-    def _compute_start_date(self, period: str) -> datetime:
-        period = period.lower()
-        value = int(period[:-1])
-        unit = period[-1]
-        today = pd.Timestamp.today().normalize()
-        if unit == "y":
-            start = today - pd.DateOffset(years=value)
-        elif unit == "m":
-            start = today - pd.DateOffset(months=value)
-        else:
-            start = today - pd.DateOffset(days=value)
-        return start.to_pydatetime()
-    def _collect_allocation_prices(
-        self, allocation_cfg: AllocationConfig
-    ) -> pd.DataFrame | None:
-        tickers: set[str] = set()
-        for profile in (
-            allocation_cfg.widening,
-            allocation_cfg.neutral,
-            allocation_cfg.tightening,
-        ):
-            tickers.update(profile.weights.keys())
-        if not tickers:
-            return None
-        client = AllocationAssetClient(self.raw_data_dir)
-        period = allocation_cfg.optimization.lookback
-        try:
-            prices = client.get_prices(sorted(tickers), period)
-        except Exception:
-            return None
-        return prices

--- a/crew/yields/insights.py
+++ b/crew/yields/insights.py
@@ -1,218 +1,51 @@
 from __future__ import annotations
-from typing import Any, Dict, List
+
+from typing import Any, Dict
+
 import pandas as pd
+
+
 def build_insight_markdown(analysis_payload: Dict[str, Any]) -> str:
-    metrics_frame = analysis_payload["metrics"]
-    snapshot = analysis_payload["snapshot"]
-    edges = analysis_payload["edges"]
-    allocation = analysis_payload.get("allocation")
-    date_start = metrics_frame.index.min()
-    date_end = metrics_frame.index.max()
-    lines: List[str] = []
-    lines.append("
-    lines.append("")
-    lines.append("
-    if pd.isna(date_start) or pd.isna(date_end):
-        lines.append("Insufficient data to compute coverage.")
+    """Return a compact optional summary for canonical Treasury output."""
+
+    snapshot = analysis_payload.get("spread_snapshot", pd.DataFrame())
+    signals = analysis_payload.get("signals", pd.DataFrame())
+    lines = ["## 正準カーブ・スプレッド", ""]
+    if not isinstance(snapshot, pd.DataFrame) or snapshot.empty:
+        lines.append("正準カーブ・スプレッドはありません。")
         return "\n".join(lines)
-    lines.append(f"- Date range: {date_start.date()} → {date_end.date()}")
-    lines.append(f"- Pairs analysed: {len(snapshot)}")
-    lines.append("")
-    if allocation:
-        lines.append("
-        lines.append(f"- Regime: **{allocation['regime']}**")
-        method = allocation.get("method", "static")
-        lines.append(f"- Method: {method.title()}")
-        lines.append(f"- Latest z-score: {allocation['z_score']:.2f}")
-        lines.append(f"- Spread: {allocation['spread_bp']:.1f} bp")
-        sharpe = allocation.get("sharpe")
-        if sharpe is not None:
-            lines.append(f"- Estimated Sharpe: {sharpe}")
-        lines.append("")
-        alloc_table = pd.DataFrame(
-            [
-                {"Asset": asset, "Weight": f"{weight:.2%}"}
-                for asset, weight in allocation["weights"].items()
-            ]
-        )
-        lines.append(
-            _format_table(alloc_table, ["Asset", "Weight"], ["Asset", "Weight"])
-        )
-        lines.append("")
-        alloc_metrics = allocation.get("metrics") or allocation.get("base_metrics")
-        if alloc_metrics:
-            metric_rows = []
-            for key in [
-                "annual_return",
-                "annual_volatility",
-                "sharpe",
-                "max_drawdown",
-                "total_return",
-            ]:
-                value = alloc_metrics.get(key)
-                if value is not None:
-                    metric_rows.append(
-                        {"Metric": key.replace("_", " ").title(), "Value": value}
-                    )
-            if metric_rows:
-                lines.append(
-                    _format_table(
-                        pd.DataFrame(metric_rows),
-                        ["Metric", "Value"],
-                        ["Metric", "Value"],
-                    )
-                )
-                lines.append("")
-        if method == "optimized" and allocation.get("base_metrics"):
-            base_metrics = allocation["base_metrics"]
-            base_rows = []
-            for key in [
-                "annual_return",
-                "annual_volatility",
-                "sharpe",
-                "max_drawdown",
-                "total_return",
-            ]:
-                value = base_metrics.get(key)
-                if value is not None:
-                    base_rows.append(
-                        {"Base Metric": key.replace("_", " ").title(), "Value": value}
-                    )
-            if base_rows:
-                lines.append(
-                    _format_table(
-                        pd.DataFrame(base_rows),
-                        ["Base Metric", "Value"],
-                        ["Base Metric", "Value"],
-                    )
-                )
-                lines.append("")
-        opt_meta = allocation.get("optimization_meta")
-        if opt_meta is not None:
-            meta_table = pd.DataFrame(
-                [
-                    {"Param": "Lookback", "Value": opt_meta.get("lookback")},
-                    {"Param": "Samples", "Value": opt_meta.get("sample_size")},
-                    {"Param": "Risk-free", "Value": opt_meta.get("risk_free_rate")},
-                ]
-            )
-            lines.append(
-                _format_table(meta_table, ["Param", "Value"], ["Param", "Value"])
-            )
-            lines.append("")
-        sensitivity = allocation.get("sensitivity")
-        if sensitivity:
-            sens_table = pd.DataFrame(sensitivity)
-            lines.append(
-                _format_table(
-                    sens_table,
-                    sens_table.columns.tolist(),
-                    [col.replace("_", " ").title() for col in sens_table.columns],
-                )
-            )
-            lines.append("")
-    if snapshot.empty:
-        lines.append("No spreads available for summary.")
-        return "\n".join(lines)
-    latest_table = snapshot.copy()
-    latest_table["latest_date"] = latest_table["latest_date"].dt.date
-    latest_table["spread_bp"] = latest_table["spread_bp"].round(1)
-    latest_table["spread"] = latest_table["spread"].round(4)
-    latest_table["z_score"] = latest_table["z_score"].round(2)
-    latest_table["junk_yield"] = latest_table["junk_yield"].round(2)
-    latest_table["treasury_yield"] = latest_table["treasury_yield"].round(2)
-    lines.append("
-    lines.append(
-        _format_table(
-            latest_table,
-            [
-                "pair",
-                "latest_date",
-                "spread_bp",
-                "z_score",
-                "junk_yield",
-                "treasury_yield",
-            ],
-            ["Pair", "Date", "Spread (bp)", "Z", "Junk %", "Treasury %"],
-        )
+
+    lines.extend(
+        [
+            "| 指標 | 観測日 | 短期 | 長期 | スプレッド | 20日変化 | z値 |",
+            "| --- | --- | ---: | ---: | ---: | ---: | ---: |",
+        ]
     )
-    lines.append("")
-    if edges.empty:
-        lines.append("
-        lines.append("No z-score triggered events within the sampled window.")
-        return "\n".join(lines)
-    lines.append("
-    lines.append(f"- Total signals: {len(edges)}")
-    lines.append("")
-    counts = edges.groupby(["pair", "direction"]).size().reset_index(name="signals")
-    lines.append(
-        _format_table(
-            counts, ["pair", "direction", "signals"], ["Pair", "Direction", "Count"]
-        )
-    )
-    lines.append("")
-    recent_start = edges["date"].max() - pd.Timedelta(days=90)
-    recent_edges = edges[edges["date"] >= recent_start]
-    lines.append("
-    if recent_edges.empty:
-        lines.append("No signals in the last 90 days.")
-    else:
-        recent_stats = recent_edges.groupby("pair").agg(
-            signals=("pair", "size"),
-            median_z=("z_score", lambda x: float(pd.Series(x).abs().median())),
-            median_spread_bp=("spread_bp", "median"),
-        )
-        recent_stats = recent_stats.reset_index()
-        recent_stats["median_z"] = recent_stats["median_z"].round(2)
-        recent_stats["median_spread_bp"] = recent_stats["median_spread_bp"].round(1)
+    for _, row in snapshot.sort_values("spread").iterrows():
         lines.append(
-            _format_table(
-                recent_stats,
-                ["pair", "signals", "median_z", "median_spread_bp"],
-                ["Pair", "Signals", "Median |Z|", "Median bp"],
+            "| {spread} | {date} | {short:.2f}% | {long:.2f}% | "
+            "{level:+.1f}bp | {change} | {z} |".format(
+                spread=row["spread"],
+                date=pd.Timestamp(row["latest_date"]).date(),
+                short=float(row["short_rate_pct"]),
+                long=float(row["long_rate_pct"]),
+                level=float(row["spread_bp"]),
+                change=_format_bp(row.get("change_20d_bp")),
+                z=_format_number(row.get("z_score")),
             )
         )
-    lines.append("")
-    try:
-        spread_bp = metrics_frame.xs("spread_bp", axis=1, level=1)
-    except (KeyError, ValueError):
-        spread_bp = pd.DataFrame()
-    if not spread_bp.empty:
-        dist = spread_bp.agg(["mean", "median", "max", "min"]).T.reset_index()
-        dist = dist.rename(
-            columns={
-                "index": "pair",
-                "mean": "mean",
-                "median": "median",
-                "max": "max",
-                "min": "min",
-            }
-        )
-        dist["mean"] = dist["mean"].round(1)
-        dist["median"] = dist["median"].round(1)
-        dist["max"] = dist["max"].round(1)
-        dist["min"] = dist["min"].round(1)
-        lines.append("
-        lines.append(
-            _format_table(
-                dist,
-                ["pair", "mean", "median", "max", "min"],
-                ["Pair", "Mean", "Median", "Max", "Min"],
-            )
-        )
-        lines.append("")
+    signal_count = len(signals) if isinstance(signals, pd.DataFrame) else 0
+    lines.extend(["", f"閾値超過イベント: {signal_count}件"])
     return "\n".join(lines)
-def _format_table(df: pd.DataFrame, columns: List[str], headers: List[str]) -> str:
-    table_lines: List[str] = []
-    table_lines.append("| " + " | ".join(headers) + " |")
-    table_lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
-    for _, row in df[columns].iterrows():
-        formatted: List[str] = []
-        for col in columns:
-            value = row[col]
-            if isinstance(value, float):
-                formatted.append(f"{value:.2f}")
-            else:
-                formatted.append(str(value))
-        table_lines.append("| " + " | ".join(formatted) + " |")
-    return "\n".join(table_lines)
+
+
+def _format_bp(value: object) -> str:
+    if value is None or pd.isna(value):
+        return "—"
+    return f"{float(value):+.1f}bp"
+
+
+def _format_number(value: object) -> str:
+    if value is None or pd.isna(value):
+        return "—"
+    return f"{float(value):+.2f}"

--- a/crew/yields/reporting.py
+++ b/crew/yields/reporting.py
@@ -1,10 +1,24 @@
 from __future__ import annotations
-import json
+
+from datetime import datetime
 from pathlib import Path
 from typing import Dict
+from zoneinfo import ZoneInfo
+
 import pandas as pd
+
 from crew.yields.config import YieldSpreadConfig
-from crew.yields.insights import build_insight_markdown
+
+
+_RATE_LABELS = {
+    "us_2y": "米国2年",
+    "us_10y": "米国10年",
+    "us_30y": "米国30年",
+    "us_10y_real": "米国10年実質金利",
+    "us_10y_breakeven": "米国10年期待インフレ",
+}
+
+
 class YieldSpreadReporter:
     def __init__(
         self, config: YieldSpreadConfig, processed_dir: Path, report_dir: Path
@@ -14,190 +28,193 @@ class YieldSpreadReporter:
         self.report_dir = report_dir
         self.processed_dir.mkdir(parents=True, exist_ok=True)
         self.report_dir.mkdir(parents=True, exist_ok=True)
-    def persist(self, analysis_payload: Dict[str, object]) -> Dict[str, Path]:
-        series_frame = analysis_payload["series"]
-        metrics_frame = analysis_payload["metrics"]
-        edges_frame = analysis_payload["edges"]
-        snapshot_frame = analysis_payload["snapshot"]
-        asset_prices = analysis_payload.get("asset_prices")
-        allocation_payload = analysis_payload.get("allocation")
-        stored_paths: Dict[str, Path] = {}
-        series_path = self.processed_dir / "yield_series.parquet"
-        series_frame.to_parquet(series_path)
-        stored_paths["series"] = series_path
-        metrics_path = self.processed_dir / "metrics.parquet"
-        metrics_frame.to_parquet(metrics_path)
-        stored_paths["metrics"] = metrics_path
-        edges_path = self.processed_dir / "edges.parquet"
-        edges_frame.to_parquet(edges_path)
-        stored_paths["edges"] = edges_path
-        snapshot_path = self.processed_dir / "snapshot.parquet"
-        snapshot_frame.to_parquet(snapshot_path)
-        stored_paths["snapshot"] = snapshot_path
-        if isinstance(asset_prices, pd.DataFrame):
-            asset_price_path = self.processed_dir / "allocation_prices.parquet"
-            asset_prices.to_parquet(asset_price_path)
-            stored_paths["allocation_prices"] = asset_price_path
-        if allocation_payload is not None:
-            allocation_path = self.processed_dir / "allocation.json"
-            allocation_path.write_text(json.dumps(allocation_payload, indent=2))
-            stored_paths["allocation"] = allocation_path
-        report_path = self.report_dir / "yield_spread_report.md"
-        report_markdown = self._build_report(
-            snapshot_frame, edges_frame, allocation_payload
+
+    def persist(self, payload: Dict[str, object]) -> Dict[str, Path]:
+        stored: Dict[str, Path] = {}
+        for key in (
+            "rates",
+            "treasury_curve",
+            "metrics",
+            "signals",
+            "spread_snapshot",
+            "macro_snapshot",
+            "curve_snapshot",
+            "provenance",
+        ):
+            value = payload.get(key)
+            if isinstance(value, pd.DataFrame):
+                path = self.processed_dir / f"{key}.parquet"
+                value.to_parquet(path)
+                stored[key] = path
+
+        report_path = self.report_dir / "report.md"
+        report_path.write_text(self._build_report(payload), encoding="utf-8")
+        stored["report"] = report_path
+        return stored
+
+    def _build_report(self, payload: Dict[str, object]) -> str:
+        spread_snapshot = _frame(payload, "spread_snapshot")
+        macro_snapshot = _frame(payload, "macro_snapshot")
+        curve_snapshot = _frame(payload, "curve_snapshot")
+        signals = _frame(payload, "signals")
+        provenance = _frame(payload, "provenance", required=False)
+        if spread_snapshot.empty or macro_snapshot.empty:
+            raise ValueError("Cannot publish a yield report without canonical snapshots")
+
+        checked_on = datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y-%m-%d")
+        latest_date = pd.to_datetime(spread_snapshot["latest_date"]).max().strftime(
+            "%Y-%m-%d"
         )
-        report_path.write_text(report_markdown)
-        stored_paths["report"] = report_path
-        insight_path = self.report_dir / "yield_spread_insights.md"
-        insight_markdown = build_insight_markdown(analysis_payload)
-        insight_path.write_text(insight_markdown)
-        stored_paths["insights"] = insight_path
-        return stored_paths
-    def _build_report(
-        self,
-        snapshot: pd.DataFrame,
-        edges: pd.DataFrame,
-        allocation: Dict[str, object] | None,
-    ) -> str:
-        lines = ["
-        if snapshot.empty:
+        freshness_gap = (pd.Timestamp(checked_on) - pd.Timestamp(latest_date)).days
+        data_score = 5 if freshness_gap <= 3 else 4 if freshness_gap <= 7 else 2
+        curve_complete = not curve_snapshot.empty and {
+            "2Y",
+            "10Y",
+            "30Y",
+        }.issubset(set(curve_snapshot["tenor"].astype(str)))
+        total_score = data_score + 5 + (5 if curve_complete else 3) + 4 + 3
+
+        lines = [
+            "# 金利・イールドスプレッド定量監査",
+            "",
+            f"更新基準日: {checked_on}",
+            "",
+            "## 結論",
+            "",
+            "期間構造を米国債金利、信用リスクをOASとして分離しました。このレポートは米国債カーブ、実質金利、期待インフレだけを扱い、ハイイールド実効利回りから10年国債を差し引く旧代理指標と固定資産配分を使用しません。",
+            "",
+            "## データ",
+            "",
+            f"正準基盤における比較可能な最新観測日は **{latest_date}** です。",
+            "",
+            "### マクロ金利",
+            "",
+            "| 系列 | 観測日 | 値 |",
+            "| --- | --- | ---: |",
+        ]
+        for _, row in macro_snapshot.sort_values("series").iterrows():
             lines.append(
-                "データが不足しているため、スナップショットを生成できませんでした。"
+                f"| {_RATE_LABELS.get(str(row['series']), row['series'])} | {pd.Timestamp(row['latest_date']).date()} | {float(row['value_pct']):.2f}% |"
             )
-            return "\n".join(lines)
-        if allocation is not None:
-            lines.append("
-            lines.append(f"- Regime: **{allocation['regime']}**")
-            method = allocation.get("method", "static")
-            lines.append(f"- Method: {method.title()}")
-            lines.append(f"- Latest z-score: {allocation['z_score']:.2f}")
-            lines.append(f"- Spread: {allocation['spread_bp']:.1f} bp")
-            sharpe = allocation.get("sharpe")
-            if sharpe is not None:
-                lines.append(f"- Estimated Sharpe: {sharpe}")
-            lines.append("")
-            opt_meta = allocation.get("optimization_meta")
-            if opt_meta is not None:
-                lines.append("| Param | Value |")
-                lines.append("| --- | --- |")
-                lines.append(f"| Lookback | {opt_meta.get('lookback')} |")
-                lines.append(f"| Samples | {opt_meta.get('sample_size')} |")
-                lines.append(f"| Risk-free | {opt_meta.get('risk_free_rate')} |")
-                lines.append("")
-            metrics = allocation.get("metrics") or allocation.get("base_metrics")
-            if metrics:
-                lines.append("| Metric | Value |")
-                lines.append("| --- | --- |")
-                for key in [
-                    "annual_return",
-                    "annual_volatility",
-                    "sharpe",
-                    "max_drawdown",
-                    "total_return",
-                ]:
-                    value = metrics.get(key)
-                    if value is None:
-                        continue
-                    formatted = (
-                        f"{value:.4f}" if isinstance(value, (int, float)) else value
-                    )
-                    lines.append(f"| {key.replace('_', ' ').title()} | {formatted} |")
-                lines.append("")
-            if method == "optimized" and allocation.get("base_metrics"):
-                base_metrics = allocation["base_metrics"]
-                lines.append("| Base Metric | Value |")
-                lines.append("| --- | --- |")
-                for key in [
-                    "annual_return",
-                    "annual_volatility",
-                    "sharpe",
-                    "max_drawdown",
-                    "total_return",
-                ]:
-                    value = base_metrics.get(key)
-                    if value is None:
-                        continue
-                    formatted = (
-                        f"{value:.4f}" if isinstance(value, (int, float)) else value
-                    )
-                    lines.append(f"| {key.replace('_', ' ').title()} | {formatted} |")
-                lines.append("")
-            sensitivity = allocation.get("sensitivity")
-            if sensitivity:
-                lines.append("| Sample Size | Sharpe | Ann. Return | Ann. Vol |")
-                lines.append("| --- | --- | --- | --- |")
-                for row in sensitivity:
-                    sharpe_val = row.get("sharpe")
-                    ann_ret = row.get("annual_return")
-                    ann_vol = row.get("annual_volatility")
-                    sharpe_str = (
-                        f"{sharpe_val:.4f}"
-                        if isinstance(sharpe_val, (int, float))
-                        else sharpe_val
-                    )
-                    ann_ret_str = (
-                        f"{ann_ret:.4f}"
-                        if isinstance(ann_ret, (int, float))
-                        else ann_ret
-                    )
-                    ann_vol_str = (
-                        f"{ann_vol:.4f}"
-                        if isinstance(ann_vol, (int, float))
-                        else ann_vol
-                    )
-                    lines.append(
-                        f"| {row.get('sample_size')} | {sharpe_str} | {ann_ret_str} | {ann_vol_str} |"
-                    )
-                lines.append("")
-                lines.append("")
-            lines.append("| Asset | Weight |")
-            lines.append("| --- | --- |")
-            for asset, weight in allocation["weights"].items():
-                lines.append(f"| {asset} | {weight:.2%} |")
-            lines.append("")
-        lines.append("
-        lines.append("| Pair | Date | Spread (bp) | Z | Junk % | Treasury % |")
-        lines.append("| --- | --- | --- | --- | --- | --- |")
-        for _, row in snapshot.sort_values(
-            "z_score", key=lambda s: s.abs(), ascending=False
-        ).iterrows():
-            date_str = row["latest_date"].date()
-            lines.append(
-                f"| {row['pair']} | {date_str} | {row['spread_bp']:.1f} | {row['z_score']:.2f} | "
-                f"{row['junk_yield']:.2f} | {row['treasury_yield']:.2f} |"
-            )
-        lines.append("")
-        lines.append("
-        if edges.empty:
-            lines.append(
-                "しきい値を超えるイールドスプレッドのイベントは検出されませんでした。"
-            )
-            return "\n".join(lines)
-        lines.append(
-            "| Date | Pair | Direction | Spread (bp) | Z | Junk % | Treasury % |"
+
+        lines.extend(
+            [
+                "",
+                "### カーブ・スプレッド",
+                "",
+                "| 指標 | 観測日 | 短期 | 長期 | スプレッド | 20日変化 | z値 |",
+                "| --- | --- | ---: | ---: | ---: | ---: | ---: |",
+            ]
         )
-        lines.append("| --- | --- | --- | --- | --- | --- | --- |")
-        for _, row in edges.sort_values("date").iterrows():
-            date_str = row["date"].strftime("%Y-%m-%d")
+        for _, row in spread_snapshot.sort_values("spread").iterrows():
             lines.append(
-                f"| {date_str} | {row['pair']} | {row['direction']} | {row['spread_bp']:.1f} | "
-                f"{row['z_score']:.2f} | {row['junk_yield']:.2f} | {row['treasury_yield']:.2f} |"
+                f"| {row['spread']} | {pd.Timestamp(row['latest_date']).date()} | {float(row['short_rate_pct']):.2f}% | {float(row['long_rate_pct']):.2f}% | {float(row['spread_bp']):+.1f}bp | {_format_bp(row['change_20d_bp'])} | {_format_number(row['z_score'])} |"
             )
-        lines.append("")
-        forecasts = analysis_payload.get("forecasts")
-        if forecasts:
-            lines.append("
-            for pair, forecast_data in forecasts.items():
-                if isinstance(forecast_data, dict) and "error" in forecast_data:
-                    lines.append(f"
-                    continue
-                if not forecast_data:
-                    continue
-                last_forecast = forecast_data[-1]
-                lines.append(f"
-                lines.append(f"Prediction End: {last_forecast.get('date', 'N/A')}")
+
+        if not curve_snapshot.empty:
+            curve_date = pd.to_datetime(curve_snapshot["observation_date"]).max().date()
+            lines.extend(
+                [
+                    "",
+                    f"### 米国財務省パー・イールド・カーブ（{curve_date}）",
+                    "",
+                    "| 年限 | 利回り |",
+                    "| --- | ---: |",
+                ]
+            )
+            for _, row in curve_snapshot.iterrows():
+                lines.append(f"| {row['tenor']} | {float(row['value']):.2f}% |")
+
+        lines.extend(
+            [
+                "",
+                "## 定量分析",
+                "",
+                f"各スプレッドは長期年限から短期年限を引き、{self.config.rolling_window}観測の移動平均・標準偏差でz値を計算します。異なる観測日の金利を直接差し引かず、欠損日は前方補完しません。",
+                "",
+            ]
+        )
+        if signals.empty:
+            lines.append("z値と20日変化の両閾値を満たす直近イベントはありません。")
+        else:
+            lines.extend(
+                [
+                    "直近の閾値超過:",
+                    "",
+                    "| 日付 | 指標 | 方向 | スプレッド | 20日変化 | z値 |",
+                    "| --- | --- | --- | ---: | ---: | ---: |",
+                ]
+            )
+            for _, row in signals.sort_values("date").tail(10).iterrows():
                 lines.append(
-                    f"Predicted Spread: {last_forecast.get('close', 'N/A'):.2f}"
+                    f"| {pd.Timestamp(row['date']).date()} | {row['spread']} | {row['direction']} | {float(row['spread_bp']):+.1f}bp | {float(row['change_20d_bp']):+.1f}bp | {float(row['z_score']):+.2f} |"
                 )
-                lines.append("")
+
+        lines.extend(
+            [
+                "",
+                "## 評価",
+                "",
+                "| 評価軸 | 点数 | 根拠 |",
+                "| --- | ---: | --- |",
+                f"| データ鮮度 | {data_score}/5 | 最新比較日から確認日まで{freshness_gap}日 |",
+                "| 定義の妥当性 | 5/5 | 国債カーブ、実質金利、期待インフレを分離 |",
+                f"| カーブ完全性 | {5 if curve_complete else 3}/5 | 2年・10年・30年の同日値を確認 |",
+                "| ビンテージ管理 | 4/5 | 観測日、FRED realtime期間、取得時刻を保持 |",
+                "| 配分接続 | 3/5 | 状態判定は可能、固定配分への自動接続は停止 |",
+                f"| **合計** | **{total_score}/25** | **正準金利経路へ移行済み** |",
+                "",
+                "## 限界と反証条件",
+                "",
+                "- パー・イールド、コンスタント・マチュリティ、ゼロクーポン金利を同一概念として扱いません。",
+                "- 名目カーブだけで景気、為替、株価の方向を断定しません。",
+                "- 実質金利と期待インフレは公表日の差を確認し、無条件に同日合成しません。",
+                "- 固定配分やKronos予測は、アウト・オブ・サンプル検証が完了するまで公開評価へ接続しません。",
+                "",
+                "## 一次情報",
+                "",
+            ]
+        )
+        urls = []
+        if not provenance.empty and "_source_url" in provenance.columns:
+            urls.extend(
+                sorted(set(str(value) for value in provenance["_source_url"].dropna()))
+            )
+        if not curve_snapshot.empty and "_source_url" in curve_snapshot.columns:
+            urls.extend(
+                sorted(
+                    set(str(value) for value in curve_snapshot["_source_url"].dropna())
+                )
+            )
+        urls = sorted(set(urls)) or [
+            "https://home.treasury.gov/resource-center/data-chart-center/interest-rates",
+            "https://fred.stlouisfed.org/series/DGS10",
+            "https://fred.stlouisfed.org/series/DFII10",
+            "https://fred.stlouisfed.org/series/T10YIE",
+        ]
+        lines.extend(f"- {url}" for url in urls)
+        lines.append("")
         return "\n".join(lines)
+
+
+def _frame(
+    payload: Dict[str, object], key: str, *, required: bool = True
+) -> pd.DataFrame:
+    value = payload.get(key)
+    if isinstance(value, pd.DataFrame):
+        return value
+    if required:
+        raise TypeError(f"Expected DataFrame payload: {key}")
+    return pd.DataFrame()
+
+
+def _format_bp(value: object) -> str:
+    if value is None or pd.isna(value):
+        return "—"
+    return f"{float(value):+.1f}bp"
+
+
+def _format_number(value: object) -> str:
+    if value is None or pd.isna(value):
+        return "—"
+    return f"{float(value):+.2f}"

--- a/tests/data_platform/test_canonical_migrations.py
+++ b/tests/data_platform/test_canonical_migrations.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from crew.credit.analysis import CreditSpreadAnalyzer
+from crew.credit.config import CreditSpreadConfig
+from crew.data_platform.consumer import sec_13f_holdings
+from crew.data_platform.contracts import DatasetBatch
+from crew.data_platform.gold import refresh_gold_views
+from crew.data_platform.sources.fred import parse_fred_public_csv
+from crew.data_platform.sources.sec import parse_13f_information_table
+from crew.data_platform.storage import DataPlatformStorage
+from crew.yields.analysis import YieldSpreadAnalyzer
+from crew.yields.config import YieldSpreadConfig
+
+
+def test_parse_fred_public_csv() -> None:
+    rows = parse_fred_public_csv(
+        label="us_10y",
+        series_id="DGS10",
+        payload=b"DATE,DGS10\n2026-08-01,4.70\n2026-08-02,.\n",
+        retrieval_date="2026-08-04",
+    )
+    assert len(rows) == 1
+    assert rows[0]["value"] == 4.70
+    assert str(rows[0]["realtime_start"]) == "2026-08-04"
+
+
+def test_parse_sec_13f_information_table() -> None:
+    payload = b"""<?xml version='1.0' encoding='UTF-8'?>
+    <informationTable xmlns='http://www.sec.gov/edgar/document/thirteenf/informationtable'>
+      <infoTable>
+        <nameOfIssuer>EXAMPLE INC</nameOfIssuer>
+        <titleOfClass>COM</titleOfClass>
+        <cusip>123456789</cusip>
+        <value>250000</value>
+        <shrsOrPrnAmt><sshPrnamt>1000</sshPrnamt><sshPrnamtType>SH</sshPrnamtType></shrsOrPrnAmt>
+        <investmentDiscretion>SOLE</investmentDiscretion>
+        <votingAuthority><Sole>1000</Sole><Shared>0</Shared><None>0</None></votingAuthority>
+      </infoTable>
+    </informationTable>"""
+    rows = parse_13f_information_table(
+        entity_name="manager",
+        cik="0000000001",
+        accession_number="0000000001-26-000001",
+        report_date="2026-06-30",
+        filing_date="2026-08-14",
+        source_url="https://www.sec.gov/example.xml",
+        payload=payload,
+    )
+    assert len(rows) == 1
+    assert rows[0]["cusip"] == "123456789"
+    assert rows[0]["shares_or_principal"] == 1000.0
+    assert len(rows[0]["holding_id"]) == 64
+
+
+def test_latest_13f_gold_view(tmp_path: Path) -> None:
+    root = tmp_path / "platform"
+    storage = DataPlatformStorage(root)
+    run_id = "20260804T000000Z-13f"
+    storage.start_run(run_id, ["sec_edgar"])
+    frame = pd.DataFrame(
+        [
+            _holding("old", "2026-03-31", "2026-05-15", 100.0),
+            _holding("new", "2026-06-30", "2026-08-14", 200.0),
+        ]
+    )
+    batch = DatasetBatch(
+        dataset="sec_13f_holdings",
+        source="sec_edgar",
+        frame=frame,
+        primary_key=("holding_id",),
+        source_url="https://www.sec.gov/example.xml",
+        raw_payload=b"fixture",
+    )
+    storage.persist(run_id, batch)
+    storage.finish_run(run_id, status="success")
+    refresh_gold_views(storage.catalog_path)
+
+    latest = sec_13f_holdings(
+        entity_names=["manager"], latest_only=True, root=root
+    )
+    assert list(latest["holding_id"]) == ["new"]
+    assert latest.iloc[0]["reported_value"] == 200.0
+
+
+def test_credit_analyzer_uses_oas_levels() -> None:
+    dates = pd.date_range("2026-01-01", periods=80, freq="D")
+    frame = pd.DataFrame(
+        {
+            "us_corporate_oas": range(80),
+            "us_bbb_oas": range(10, 90),
+            "us_high_yield_oas": range(20, 100),
+        },
+        index=dates,
+        dtype=float,
+    ) / 100
+    analyzer = CreditSpreadAnalyzer(
+        CreditSpreadConfig(name="credit", minimum_periods=20, rolling_window=30)
+    )
+    result = analyzer.evaluate({"oas": frame, "provenance": pd.DataFrame()})
+    assert set(result["snapshot"]["series"]) == {
+        "us_corporate_oas",
+        "us_bbb_oas",
+        "us_high_yield_oas",
+    }
+    assert "ratio" not in result["metrics"].columns.get_level_values(1)
+
+
+def test_yield_analyzer_separates_curve_spreads() -> None:
+    dates = pd.date_range("2026-01-01", periods=80, freq="D")
+    rates = pd.DataFrame(
+        {
+            "us_2y": 4.0,
+            "us_10y": 4.5,
+            "us_30y": 5.0,
+            "us_10y_real": 2.0,
+            "us_10y_breakeven": 2.5,
+        },
+        index=dates,
+    )
+    curve = pd.DataFrame(
+        [
+            {"observation_date": dates[-1], "tenor": "2Y", "value": 4.0},
+            {"observation_date": dates[-1], "tenor": "10Y", "value": 4.5},
+            {"observation_date": dates[-1], "tenor": "30Y", "value": 5.0},
+        ]
+    )
+    analyzer = YieldSpreadAnalyzer(
+        YieldSpreadConfig(name="yields", minimum_periods=20, rolling_window=30)
+    )
+    result = analyzer.evaluate(
+        {
+            "rates": rates,
+            "treasury_curve": curve,
+            "rates_provenance": pd.DataFrame(),
+        }
+    )
+    snapshot = result["spread_snapshot"].set_index("spread")
+    assert snapshot.loc["us_2s10s", "spread_bp"] == 50.0
+    assert snapshot.loc["us_10s30s", "spread_bp"] == 50.0
+
+
+def _holding(
+    holding_id: str, report_date: str, filing_date: str, value: float
+) -> dict[str, object]:
+    return {
+        "holding_id": holding_id,
+        "entity_name": "manager",
+        "entity_cik": "0000000001",
+        "accession_number": f"accession-{holding_id}",
+        "report_date": pd.Timestamp(report_date).date(),
+        "filing_date": pd.Timestamp(filing_date).date(),
+        "issuer": "EXAMPLE INC",
+        "title_of_class": "COM",
+        "cusip": "123456789",
+        "figi": None,
+        "reported_value": value,
+        "reported_value_unit": "SEC_13F_as_filed",
+        "shares_or_principal": value,
+        "shares_or_principal_type": "SH",
+        "put_call": None,
+        "investment_discretion": "SOLE",
+        "other_manager": None,
+        "voting_sole": value,
+        "voting_shared": 0.0,
+        "voting_none": 0.0,
+        "source_document_url": "https://www.sec.gov/example.xml",
+    }

--- a/tests/data_platform/test_fred_public_csv_headers.py
+++ b/tests/data_platform/test_fred_public_csv_headers.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from crew.data_platform.sources.fred import parse_fred_public_csv
+
+
+@pytest.mark.parametrize("date_header", ["observation_date", "DATE", "date"])
+def test_parse_fred_public_csv_date_header_variants(date_header: str) -> None:
+    payload = (
+        f"{date_header},DGS10\n2026-08-01,4.70\n2026-08-02,.\n"
+    ).encode("utf-8")
+    rows = parse_fred_public_csv(
+        label="us_10y",
+        series_id="DGS10",
+        payload=payload,
+        retrieval_date="2026-08-04",
+    )
+    assert len(rows) == 1
+    assert str(rows[0]["observation_date"]) == "2026-08-01"
+    assert rows[0]["value"] == 4.70

--- a/tests/data_platform/test_public_status.py
+++ b/tests/data_platform/test_public_status.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from crew.data_platform.contracts import DatasetBatch
+from crew.data_platform.public_status import build_public_status, export_public_status
+from crew.data_platform.storage import DataPlatformStorage
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PLATFORM_CONFIG = PROJECT_ROOT / "config" / "data_platform.yaml"
+MIGRATION_CONFIG = PROJECT_ROOT / "config" / "use_case_data_status.yaml"
+
+
+def test_status_is_degraded_before_first_snapshot(tmp_path: Path) -> None:
+    status = build_public_status(
+        platform_config_path=PLATFORM_CONFIG,
+        migration_config_path=MIGRATION_CONFIG,
+        root=tmp_path / "missing",
+    )
+    assert status["overall_status"] == "degraded"
+    assert status["summary"] == {
+        "use_case_count": 10,
+        "canonical_ok": 0,
+        "controlled_blocks": 6,
+        "awaiting_snapshot": 4,
+    }
+
+
+def test_status_is_ok_when_all_canonical_datasets_exist(tmp_path: Path) -> None:
+    root = tmp_path / "platform"
+    storage = DataPlatformStorage(root)
+    run_id = "20260804T000000Z-status"
+    storage.start_run(run_id, ["fixture"])
+    for dataset in (
+        "credit_oas",
+        "rates_macro",
+        "treasury_par_yield_curve",
+        "sec_filings",
+        "sec_company_facts",
+        "sec_13f_holdings",
+    ):
+        batch = DatasetBatch(
+            dataset=dataset,
+            source="fixture",
+            frame=pd.DataFrame([{"id": f"{dataset}-1", "value": 1.0}]),
+            primary_key=("id",),
+            source_url=f"https://example.com/{dataset}",
+            raw_payload=dataset.encode("utf-8"),
+            metadata={"retrieval_mode": "fixture"},
+        )
+        storage.persist(run_id, batch)
+    storage.finish_run(run_id, status="success")
+
+    output = tmp_path / "status.json"
+    status = export_public_status(
+        output_path=output,
+        platform_config_path=PLATFORM_CONFIG,
+        migration_config_path=MIGRATION_CONFIG,
+        root=root,
+    )
+    assert output.is_file()
+    assert status["overall_status"] == "ok"
+    assert status["summary"]["canonical_ok"] == 4
+    assert status["summary"]["controlled_blocks"] == 6
+    assert status["summary"]["awaiting_snapshot"] == 0
+    assert all(row["operational"] for row in status["use_cases"])

--- a/web/audit_data_status.py
+++ b/web/audit_data_status.py
@@ -45,20 +45,29 @@ def audit() -> None:
             failures.append("invalid use-case status row")
             continue
         if row.get("runtime_state") not in ALLOWED_STATES:
-            failures.append(f"invalid state for {row.get('slug')}: {row.get('runtime_state')}")
+            failures.append(
+                f"invalid state for {row.get('slug')}: {row.get('runtime_state')}"
+            )
         if not row.get("owner_source") or not row.get("note"):
             failures.append(f"missing owner/note for {row.get('slug')}")
         if row.get("declared_state") == "canonical_active" and not row.get(
             "required_datasets"
         ):
-            failures.append(f"canonical use case has no datasets: {row.get('slug')}")
+            failures.append(
+                f"canonical use case has no datasets: {row.get('slug')}"
+            )
 
     summary = status.get("summary", {})
     if summary.get("use_case_count") != 10:
         failures.append("summary use_case_count must be 10")
     if status.get("overall_status") == "ok":
-        if summary.get("canonical_ok") != 4 or summary.get("awaiting_snapshot") != 0:
-            failures.append("OK requires four canonical use cases and no pending snapshot")
+        if (
+            summary.get("canonical_ok") != 4
+            or summary.get("awaiting_snapshot") != 0
+        ):
+            failures.append(
+                "OK requires four canonical use cases and no pending snapshot"
+            )
     elif status.get("overall_status") != "degraded":
         failures.append("overall_status must be ok or degraded")
 
@@ -66,15 +75,22 @@ def audit() -> None:
         '<html lang="ja">': "Japanese language",
         'id="data-platform-status"': "data platform landmark",
         'id="use-case-status"': "use-case status section",
-        'class="case-table data-status-table"': "dataset table",
         'class="case-table data-use-case-table"': "use-case table",
-        'data-platform-overall=': "overall status marker",
+        "data-platform-overall=": "overall status marker",
         'href="../assets/site.css"': "site stylesheet",
         'href="../index.html"': "home link",
     }
     for marker, label in required_page_markers.items():
         if marker not in page:
             failures.append(f"status page missing {label}")
+
+    datasets = status.get("datasets", [])
+    if datasets:
+        if 'class="case-table data-status-table"' not in page:
+            failures.append("status page missing dataset table")
+    elif "公開用スナップショット未生成" not in page:
+        failures.append("status page missing explicit empty dataset state")
+
     if 'href="data-status/index.html"' not in index:
         failures.append("home page has no data-status link")
 

--- a/web/audit_data_status.py
+++ b/web/audit_data_status.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = PROJECT_ROOT / "docs"
+STATUS_SOURCE = PROJECT_ROOT / "web" / "generated" / "data-platform-status.json"
+STATUS_PAGE = DOCS_DIR / "data-status" / "index.html"
+MANIFEST = DOCS_DIR / "site-manifest.json"
+ALLOWED_STATES = {
+    "ok",
+    "awaiting_snapshot",
+    "governed_blocked",
+    "governed_partial",
+    "private_input_required",
+}
+
+
+def audit() -> None:
+    failures: list[str] = []
+    for path in (STATUS_SOURCE, STATUS_PAGE, MANIFEST, DOCS_DIR / "index.html"):
+        if not path.is_file():
+            failures.append(f"missing required file: {path.relative_to(PROJECT_ROOT)}")
+    if failures:
+        raise RuntimeError("Data status audit failed:\n- " + "\n- ".join(failures))
+
+    status = json.loads(STATUS_SOURCE.read_text(encoding="utf-8"))
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    page = STATUS_PAGE.read_text(encoding="utf-8")
+    index = (DOCS_DIR / "index.html").read_text(encoding="utf-8")
+
+    if status.get("schema_version") != 1:
+        failures.append("status schema_version must be 1")
+    use_cases = status.get("use_cases")
+    if not isinstance(use_cases, list) or len(use_cases) != 10:
+        failures.append("status must contain exactly 10 use cases")
+        use_cases = []
+    slugs = [str(row.get("slug")) for row in use_cases if isinstance(row, dict)]
+    if len(slugs) != len(set(slugs)):
+        failures.append("status contains duplicate use-case slugs")
+    for row in use_cases:
+        if not isinstance(row, dict):
+            failures.append("invalid use-case status row")
+            continue
+        if row.get("runtime_state") not in ALLOWED_STATES:
+            failures.append(f"invalid state for {row.get('slug')}: {row.get('runtime_state')}")
+        if not row.get("owner_source") or not row.get("note"):
+            failures.append(f"missing owner/note for {row.get('slug')}")
+        if row.get("declared_state") == "canonical_active" and not row.get(
+            "required_datasets"
+        ):
+            failures.append(f"canonical use case has no datasets: {row.get('slug')}")
+
+    summary = status.get("summary", {})
+    if summary.get("use_case_count") != 10:
+        failures.append("summary use_case_count must be 10")
+    if status.get("overall_status") == "ok":
+        if summary.get("canonical_ok") != 4 or summary.get("awaiting_snapshot") != 0:
+            failures.append("OK requires four canonical use cases and no pending snapshot")
+    elif status.get("overall_status") != "degraded":
+        failures.append("overall_status must be ok or degraded")
+
+    required_page_markers = {
+        '<html lang="ja">': "Japanese language",
+        'id="data-platform-status"': "data platform landmark",
+        'id="use-case-status"': "use-case status section",
+        'class="case-table data-status-table"': "dataset table",
+        'class="case-table data-use-case-table"': "use-case table",
+        'data-platform-overall=': "overall status marker",
+        'href="../assets/site.css"': "site stylesheet",
+        'href="../index.html"': "home link",
+    }
+    for marker, label in required_page_markers.items():
+        if marker not in page:
+            failures.append(f"status page missing {label}")
+    if 'href="data-status/index.html"' not in index:
+        failures.append("home page has no data-status link")
+
+    manifest_status = manifest.get("data_platform")
+    if not isinstance(manifest_status, dict):
+        failures.append("site manifest has no data_platform entry")
+    else:
+        if manifest_status.get("path") != "data-status/index.html":
+            failures.append("manifest data platform path is incorrect")
+        if manifest_status.get("overall_status") != status.get("overall_status"):
+            failures.append("manifest/status overall values differ")
+
+    forbidden_public_keys = (
+        '"market_price"',
+        '"quantity"',
+        '"collateral_haircut"',
+        '"contract_version"',
+    )
+    source_text = STATUS_SOURCE.read_text(encoding="utf-8")
+    for forbidden in forbidden_public_keys:
+        if forbidden in source_text:
+            failures.append(f"public status exposes private field {forbidden}")
+
+    if failures:
+        raise RuntimeError("Data status audit failed:\n- " + "\n- ".join(failures))
+    print(
+        "Data status audit passed: "
+        f"overall={status['overall_status']} / use_cases=10 / "
+        f"canonical_ok={summary['canonical_ok']} / "
+        f"controlled={summary['controlled_blocks']}"
+    )
+
+
+if __name__ == "__main__":
+    audit()

--- a/web/audit_static.py
+++ b/web/audit_static.py
@@ -7,8 +7,6 @@ from urllib.parse import unquote, urlsplit
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DOCS_DIR = PROJECT_ROOT / "docs"
-CONTENT_REFRESH_DATE = "20260804"
-CONTENT_REFRESH_LABEL = "更新基準日: 2026-08-04"
 REQUIRED_CASE_FIELDS = {
     "slug",
     "title",
@@ -47,23 +45,22 @@ class LocalReferenceParser(HTMLParser):
 
 def resolve_local_reference(html_path: Path, reference: str) -> Path | None:
     parsed = urlsplit(reference)
-    if parsed.scheme or parsed.netloc or reference.startswith(("#", "mailto:", "tel:", "data:")):
+    if parsed.scheme or parsed.netloc or reference.startswith(
+        ("#", "mailto:", "tel:", "data:")
+    ):
         return None
-
     path_text = unquote(parsed.path)
     if not path_text:
         return None
-
-    if path_text.startswith("/"):
-        candidate = DOCS_DIR / path_text.lstrip("/")
-    else:
-        candidate = html_path.parent / path_text
-
+    candidate = (
+        DOCS_DIR / path_text.lstrip("/")
+        if path_text.startswith("/")
+        else html_path.parent / path_text
+    )
     candidate = candidate.resolve()
     docs_root = DOCS_DIR.resolve()
     if docs_root not in candidate.parents and candidate != docs_root:
         raise RuntimeError(f"Reference escapes docs root: {reference}")
-
     if candidate.is_dir():
         candidate = candidate / "index.html"
     return candidate
@@ -77,17 +74,24 @@ def audit() -> None:
         DOCS_DIR / "assets" / "site.js",
         DOCS_DIR / "site-manifest.json",
     ]
-    missing = [str(path.relative_to(PROJECT_ROOT)) for path in required if not path.is_file()]
+    missing = [
+        str(path.relative_to(PROJECT_ROOT))
+        for path in required
+        if not path.is_file()
+    ]
     if missing:
         raise RuntimeError(f"Missing generated site files: {', '.join(missing)}")
 
-    manifest = json.loads((DOCS_DIR / "site-manifest.json").read_text(encoding="utf-8"))
+    manifest = json.loads(
+        (DOCS_DIR / "site-manifest.json").read_text(encoding="utf-8")
+    )
     if manifest.get("schema_version") != 2:
         raise RuntimeError("Unsupported or missing site manifest schema_version 2.")
     if not manifest.get("cases") or not manifest.get("total_reports"):
         raise RuntimeError("Generated site manifest contains no reports.")
-    if manifest.get("site_latest_date") != CONTENT_REFRESH_DATE:
-        raise RuntimeError("site_latest_date does not match the audited content refresh date.")
+    site_latest_date = str(manifest.get("site_latest_date", ""))
+    if len(site_latest_date) != 8 or not site_latest_date.isdigit():
+        raise RuntimeError("site_latest_date must be a YYYYMMDD value.")
     if not manifest.get("purposes"):
         raise RuntimeError("Generated site manifest contains no research purposes.")
 
@@ -96,17 +100,17 @@ def audit() -> None:
     required_index_markers = {
         'class="skip-link"': "skip link",
         'id="research-catalogue"': "catalogue landmark",
-        'data-case-controls': "catalogue controls",
-        'data-purpose-filter': "purpose filter",
-        'data-freshness-filter': "freshness filter",
-        'data-clear-filters': "clear filters action",
-        'data-empty-state': "empty state",
+        "data-case-controls": "catalogue controls",
+        "data-purpose-filter": "purpose filter",
+        "data-freshness-filter": "freshness filter",
+        "data-clear-filters": "clear filters action",
+        "data-empty-state": "empty state",
         'data-case-view="table"': "table view container",
         'data-case-view="cards"': "card view container",
         'data-view-button="table"': "table view button",
         'data-view-button="cards"': "card view button",
         'class="case-table"': "research comparison table",
-        'data-purpose-section': "purpose groups",
+        "data-purpose-section": "purpose groups",
         'href="assets/table.css"': "table stylesheet",
     }
     for marker, label in required_index_markers.items():
@@ -115,10 +119,13 @@ def audit() -> None:
 
     manifest_report_count = 0
     manifest_companion_count = 0
+    latest_dates: list[str] = []
     for case in manifest["cases"]:
         missing_fields = sorted(REQUIRED_CASE_FIELDS.difference(case))
         if missing_fields:
-            failures.append(f"manifest: {case.get('slug', '<unknown>')} missing {missing_fields}")
+            failures.append(
+                f"manifest: {case.get('slug', '<unknown>')} missing {missing_fields}"
+            )
 
         slug = case.get("slug")
         dates = case.get("dates", [])
@@ -127,16 +134,21 @@ def audit() -> None:
         if not slug or not dates:
             failures.append(f"manifest: invalid case entry {case!r}")
             continue
-
-        if dates[0] != CONTENT_REFRESH_DATE:
+        latest_date = str(dates[0])
+        latest_dates.append(latest_date)
+        if len(latest_date) != 8 or not latest_date.isdigit():
+            failures.append(f"manifest: {slug} latest date is not YYYYMMDD: {latest_date}")
+            continue
+        if latest_date > site_latest_date:
             failures.append(
-                f"manifest: {slug} latest report is {dates[0]}, expected {CONTENT_REFRESH_DATE}"
+                f"manifest: {slug} latest date {latest_date} exceeds site latest {site_latest_date}"
             )
+        expected_refresh_label = _refresh_label(latest_date)
 
         if case.get("purpose") not in manifest["purposes"]:
             failures.append(f"manifest: {slug} purpose is not registered")
 
-        case_index = DOCS_DIR / slug / "index.html"
+        case_index = DOCS_DIR / str(slug) / "index.html"
         if not case_index.is_file():
             failures.append(f"manifest: missing {slug}/index.html")
         else:
@@ -150,16 +162,17 @@ def audit() -> None:
                 if marker not in case_text:
                     failures.append(f"{slug}/index.html: missing {label}")
 
-        latest_date = dates[0]
         latest_source_name = source_map.get(latest_date)
         if not latest_source_name:
-            failures.append(f"manifest: missing source mapping for {slug}/{latest_date}")
+            failures.append(
+                f"manifest: missing source mapping for {slug}/{latest_date}"
+            )
         else:
             latest_source = (
                 PROJECT_ROOT
                 / "output"
                 / "use_cases"
-                / slug
+                / str(slug)
                 / latest_date
                 / latest_source_name
             )
@@ -169,34 +182,38 @@ def audit() -> None:
                 )
             else:
                 source_text = latest_source.read_text(encoding="utf-8")
-                if CONTENT_REFRESH_LABEL not in source_text:
+                if expected_refresh_label not in source_text:
                     failures.append(
-                        f"{slug}/{latest_date}/{latest_source_name}: missing content refresh marker"
+                        f"{slug}/{latest_date}/{latest_source_name}: "
+                        f"missing {expected_refresh_label!r}"
                     )
                 for marker, label in REQUIRED_REPORT_SECTIONS.items():
                     if marker not in source_text:
                         failures.append(
                             f"{slug}/{latest_date}/{latest_source_name}: missing {label}"
                         )
-                primary_source_section = source_text.split("## 一次情報", maxsplit=1)
-                if len(primary_source_section) != 2 or "https://" not in primary_source_section[1]:
+                primary_section = source_text.split("## 一次情報", maxsplit=1)
+                if len(primary_section) != 2 or "https://" not in primary_section[1]:
                     failures.append(
-                        f"{slug}/{latest_date}/{latest_source_name}: primary-source section has no URL"
+                        f"{slug}/{latest_date}/{latest_source_name}: "
+                        "primary-source section has no URL"
                     )
 
-        latest_report = DOCS_DIR / slug / f"{latest_date}.html"
+        latest_report = DOCS_DIR / str(slug) / f"{latest_date}.html"
         if latest_report.is_file():
             latest_text = latest_report.read_text(encoding="utf-8")
-            if CONTENT_REFRESH_LABEL not in latest_text:
+            if expected_refresh_label not in latest_text:
                 failures.append(
-                    f"{slug}/{latest_date}.html: missing content refresh marker"
+                    f"{slug}/{latest_date}.html: missing {expected_refresh_label!r}"
                 )
             if 'id="report-content"' not in latest_text:
-                failures.append(f"{slug}/{latest_date}.html: missing report content target")
+                failures.append(
+                    f"{slug}/{latest_date}.html: missing report content target"
+                )
 
         for date in dates:
             manifest_report_count += 1
-            if not (DOCS_DIR / slug / f"{date}.html").is_file():
+            if not (DOCS_DIR / str(slug) / f"{date}.html").is_file():
                 failures.append(f"manifest: missing {slug}/{date}.html")
             companions = companion_map.get(date, [])
             if not isinstance(companions, list):
@@ -204,9 +221,14 @@ def audit() -> None:
                 continue
             for companion in companions:
                 manifest_companion_count += 1
-                if not (DOCS_DIR / slug / companion).is_file():
+                if not (DOCS_DIR / str(slug) / companion).is_file():
                     failures.append(f"manifest: missing {slug}/{companion}")
 
+    if latest_dates and max(latest_dates) != site_latest_date:
+        failures.append(
+            "manifest: site_latest_date does not equal the maximum case date "
+            f"({site_latest_date} != {max(latest_dates)})"
+        )
     if manifest_report_count != manifest["total_reports"]:
         failures.append(
             "manifest: total_reports does not match report entries "
@@ -214,7 +236,12 @@ def audit() -> None:
         )
 
     html_files = sorted(DOCS_DIR.rglob("*.html"))
-    expected_html_count = manifest_report_count + manifest_companion_count + len(manifest["cases"]) + 1
+    expected_html_count = (
+        manifest_report_count
+        + manifest_companion_count
+        + len(manifest["cases"])
+        + 1
+    )
     if len(html_files) != expected_html_count:
         failures.append(
             "generated HTML count does not match manifest "
@@ -232,7 +259,11 @@ def audit() -> None:
             failures.append(f"{relative}: missing main landmark")
         if "{{" in text or "{%" in text:
             failures.append(f"{relative}: unresolved Jinja template marker")
-        if "#0d1117" in text or "Select a use case" in text or "View analysis reports" in text:
+        if (
+            "#0d1117" in text
+            or "Select a use case" in text
+            or "View analysis reports" in text
+        ):
             failures.append(f"{relative}: legacy dashboard content remains")
 
         parser = LocalReferenceParser()
@@ -257,9 +288,13 @@ def audit() -> None:
         f"{manifest['total_reports']} reports / "
         f"{manifest_companion_count} companion pages / "
         f"{len(manifest['cases'])} cases / {len(html_files)} HTML files / "
-        f"decision catalogue enabled / quantitative evidence contract enabled / "
-        f"content refreshed {CONTENT_REFRESH_DATE}"
+        "decision catalogue enabled / quantitative evidence contract enabled / "
+        f"site latest {site_latest_date}"
     )
+
+
+def _refresh_label(date: str) -> str:
+    return f"更新基準日: {date[:4]}-{date[4:6]}-{date[6:]}"
 
 
 if __name__ == "__main__":

--- a/web/build_data_status.py
+++ b/web/build_data_status.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from build_static import DOCS_DIR, create_environment
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+STATUS_SOURCE = PROJECT_ROOT / "web" / "generated" / "data-platform-status.json"
+STATUS_OUTPUT = DOCS_DIR / "data-status" / "index.html"
+MANIFEST_PATH = DOCS_DIR / "site-manifest.json"
+
+STATE_LABELS = {
+    "ok": "正準稼働",
+    "awaiting_snapshot": "取得待ち",
+    "governed_blocked": "契約待ち・停止",
+    "governed_partial": "一部利用可能",
+    "private_input_required": "非公開入力待ち",
+}
+
+
+def build() -> None:
+    status = json.loads(STATUS_SOURCE.read_text(encoding="utf-8"))
+    _validate_status(status)
+    env = create_environment()
+    generated_at = datetime.fromisoformat(status["generated_at"]).astimezone(
+        ZoneInfo("Asia/Tokyo")
+    )
+    overall_ok = status["overall_status"] == "ok"
+    html = env.get_template("data_status.html").render(
+        status=status,
+        generated_label=generated_at.strftime("%Y-%m-%d %H:%M JST"),
+        overall_label="OK · 正準データ経路は運用可能"
+        if overall_ok
+        else "DEGRADED · 一次スナップショット待ち",
+        overall_description=(
+            "正準接続済み分析は最新スナップショットを参照し、残りは理由付きの統制状態です。"
+            if overall_ok
+            else "構成と停止契約は有効です。正準接続済み分析の一部データがまだ取得されていません。"
+        ),
+        state_labels=STATE_LABELS,
+    )
+    STATUS_OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    STATUS_OUTPUT.write_text(html, encoding="utf-8")
+    _inject_home_link()
+    _extend_manifest(status)
+    print(
+        f"Built data status page: overall={status['overall_status']} "
+        f"canonical_ok={status['summary']['canonical_ok']}"
+    )
+
+
+def _validate_status(status: dict[str, object]) -> None:
+    if status.get("schema_version") != 1:
+        raise ValueError("Unsupported data platform status schema")
+    use_cases = status.get("use_cases")
+    if not isinstance(use_cases, list) or len(use_cases) != 10:
+        raise ValueError("Public status must contain exactly 10 use cases")
+    slugs = [str(row.get("slug")) for row in use_cases if isinstance(row, dict)]
+    if len(slugs) != len(set(slugs)):
+        raise ValueError("Public status contains duplicate use-case slugs")
+    if any(
+        not isinstance(row, dict) or not row.get("runtime_state")
+        for row in use_cases
+    ):
+        raise ValueError("Every use case must expose a runtime state")
+
+
+def _inject_home_link() -> None:
+    index_path = DOCS_DIR / "index.html"
+    text = index_path.read_text(encoding="utf-8")
+    if 'href="data-status/index.html"' not in text:
+        marker = '<a href="#reading-protocol">読み方</a>'
+        replacement = marker + '\n        <a href="data-status/index.html">データ状態</a>'
+        if marker not in text:
+            raise ValueError("Could not locate the home navigation marker")
+        text = text.replace(marker, replacement, 1)
+        index_path.write_text(text, encoding="utf-8")
+
+
+def _extend_manifest(status: dict[str, object]) -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    manifest["data_platform"] = {
+        "path": "data-status/index.html",
+        "overall_status": status["overall_status"],
+        "generated_at": status["generated_at"],
+        "summary": status["summary"],
+        "catalog_present": status["catalog_present"],
+    }
+    MANIFEST_PATH.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    build()

--- a/web/generated/data-platform-status.json
+++ b/web/generated/data-platform-status.json
@@ -1,0 +1,26 @@
+{
+  "catalog_present": false,
+  "datasets": [],
+  "generated_at": "2026-08-04T10:13:00+00:00",
+  "latest_run": null,
+  "overall_status": "degraded",
+  "schema_version": 1,
+  "summary": {
+    "awaiting_snapshot": 4,
+    "canonical_ok": 0,
+    "controlled_blocks": 6,
+    "use_case_count": 10
+  },
+  "use_cases": [
+    {"slug":"credit","title":"クレジット・スプレッド","declared_state":"canonical_active","runtime_state":"awaiting_snapshot","operational":false,"owner_source":"FRED / ICE BofA","note":"ETF価格比を廃止し、公式OASへ移行済み。","required_datasets":["credit_oas"],"missing_datasets":["credit_oas"],"required_contracts":[]},
+    {"slug":"yield_spread","title":"金利・イールドスプレッド","declared_state":"canonical_active","runtime_state":"awaiting_snapshot","operational":false,"owner_source":"FRED / U.S. Treasury","note":"国債カーブ・実質金利・期待インフレを分離。","required_datasets":["rates_macro","treasury_par_yield_curve"],"missing_datasets":["rates_macro","treasury_par_yield_curve"],"required_contracts":[]},
+    {"slug":"oracle","title":"Oracle実績・予測監査","declared_state":"canonical_active","runtime_state":"awaiting_snapshot","operational":false,"owner_source":"SEC EDGAR","note":"静的実績値を廃止し、提出履歴とXBRL factsへ移行。","required_datasets":["sec_filings","sec_company_facts"],"missing_datasets":["sec_filings","sec_company_facts"],"required_contracts":[]},
+    {"slug":"legendary_investors","title":"著名投資家リサーチ","declared_state":"canonical_active","runtime_state":"awaiting_snapshot","operational":false,"owner_source":"SEC EDGAR 13F","note":"固定銘柄配列を廃止し、information tableへ移行。","required_datasets":["sec_filings","sec_13f_holdings"],"missing_datasets":["sec_filings","sec_13f_holdings"],"required_contracts":[]},
+    {"slug":"imura","title":"ファンド・指数比較","declared_state":"governed_blocked","runtime_state":"governed_blocked","operational":true,"owner_source":"fundnote株式会社","note":"公式機械可読NAV契約が整うまで数値更新を停止。","required_datasets":[],"missing_datasets":[],"required_contracts":[]},
+    {"slug":"index_7_portfolio","title":"7指数ポートフォリオ","declared_state":"governed_blocked","runtime_state":"governed_blocked","operational":true,"owner_source":"JPX / 各運用会社","note":"正式商品マスターと指数代替系列の整備待ち。","required_datasets":[],"missing_datasets":[],"required_contracts":[]},
+    {"slug":"index_etf_comparison","title":"指数ETF比較","declared_state":"governed_blocked","runtime_state":"governed_blocked","operational":true,"owner_source":"JPX / EDINET","note":"ISIN・指数・通貨・費用を揃えた商品契約待ち。","required_datasets":[],"missing_datasets":[],"required_contracts":[]},
+    {"slug":"precious_metals_spread","title":"貴金属スプレッド","declared_state":"governed_blocked","runtime_state":"governed_blocked","operational":true,"owner_source":"LBMA","note":"履歴保存・再配布ライセンスが整うまで日次シグナル停止。","required_datasets":[],"missing_datasets":[],"required_contracts":[]},
+    {"slug":"securities_collateral_loan","title":"証券担保ローン","declared_state":"private_input_required","runtime_state":"private_input_required","operational":true,"owner_source":"非公開契約・口座状態","note":"公開Pagesへ契約・口座値を出さず、入力状態だけ表示。","required_datasets":[],"missing_datasets":[],"required_contracts":[]},
+    {"slug":"semiconductors","title":"半導体サイクル","declared_state":"governed_partial","runtime_state":"governed_partial","operational":true,"owner_source":"WSTS / EDINET / 企業開示","note":"公開リリースは利用可能、会員表と企業XBRLは追加契約待ち。","required_datasets":[],"missing_datasets":[],"required_contracts":[]}
+  ]
+}

--- a/web/templates/data_status.html
+++ b/web/templates/data_status.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CrewTradeの一次データ基盤、分析移行、データ契約、最終取得状態を公開します。">
+  <meta name="theme-color" content="#fbfaf7">
+  <title>CrewTrade | データ基盤状態</title>
+  <link rel="stylesheet" href="../assets/site.css">
+  <link rel="stylesheet" href="../assets/table.css">
+  <script defer src="../assets/site.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#data-platform-status">データ基盤状態へ移動</a>
+  <header class="site-header shell">
+    <div class="header-inner">
+      <a class="brand" href="../index.html" aria-label="CrewTrade ホーム">
+        <span class="brand-mark" aria-hidden="true">CT</span><span>CrewTrade</span>
+      </a>
+      <nav class="header-links" aria-label="主要ナビゲーション">
+        <a href="../index.html">調査カタログ</a>
+        <a href="#use-case-status">分析別状態</a>
+        <a href="https://github.com/KAFKA2306/CrewTrade">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="shell" id="data-platform-status" tabindex="-1">
+    <section class="hero" aria-labelledby="page-title">
+      <div>
+        <p class="eyebrow">Canonical data platform</p>
+        <h1 id="page-title">数値より先に、データの状態を確認する。</h1>
+        <p class="hero-copy">一次ソース、取得時刻、raw SHA-256、Parquet、品質検査、分析への接続状態を公開します。取得できないデータは推測せず、停止理由または非公開入力として表示します。</p>
+        <div class="metrics" aria-label="データ基盤の公開状態">
+          <span class="metric"><strong>{{ status.summary.canonical_ok }}</strong>正準稼働</span>
+          <span class="metric"><strong>{{ status.summary.controlled_blocks }}</strong>統制状態</span>
+          <span class="metric"><strong>{{ status.summary.awaiting_snapshot }}</strong>取得待ち</span>
+          <span class="metric">生成 {{ generated_label }}</span>
+        </div>
+      </div>
+      <aside class="hero-note" aria-label="総合状態">
+        <span class="status-label">DATA PLATFORM</span>
+        <strong data-platform-overall="{{ status.overall_status }}">{{ overall_label }}</strong>
+        <p>{{ overall_description }}</p>
+      </aside>
+    </section>
+
+    <section class="section" aria-labelledby="run-title">
+      <div class="section-heading"><div><p class="eyebrow">Ingestion</p><h2 id="run-title">最新取得実行</h2></div></div>
+      {% if status.latest_run %}
+      <div class="notice">
+        <strong>{{ status.latest_run.status }}</strong>
+        <span>run <code>{{ status.latest_run.run_id }}</code></span>
+        <span>開始 {{ status.latest_run.started_at }}</span>
+        {% if status.latest_run.completed_at %}<span>完了 {{ status.latest_run.completed_at }}</span>{% endif %}
+        {% if status.latest_run.error %}<p>{{ status.latest_run.error }}</p>{% endif %}
+      </div>
+      {% else %}
+      <div class="notice"><strong>取得スナップショット待ち</strong> 設定とPages表示は有効ですが、正準カタログの公開用スナップショットはまだありません。</div>
+      {% endif %}
+    </section>
+
+    <section class="section" aria-labelledby="dataset-title">
+      <div class="section-heading"><div><p class="eyebrow">Canonical datasets</p><h2 id="dataset-title">正準データセット</h2><p>公開するのは状態・件数・来歴だけです。raw本文や非公開口座情報は公開しません。</p></div></div>
+      {% if status.datasets %}
+      <div class="case-table-shell" tabindex="0" aria-label="正準データセット一覧。横方向にスクロールできます。">
+        <table class="case-table data-status-table">
+          <caption>データセット、一次ソース、行数、取得日時、品質状態</caption>
+          <thead><tr><th scope="col">データセット</th><th scope="col">一次ソース</th><th scope="col">行数</th><th scope="col">取得日時</th><th scope="col">品質</th><th scope="col">取得方式</th></tr></thead>
+          <tbody>
+          {% for dataset in status.datasets %}
+            <tr>
+              <td><strong>{{ dataset.dataset }}</strong><small class="cell-secondary"><code>{{ dataset.raw_sha256[:16] }}</code></small></td>
+              <td><a href="{{ dataset.source_url }}">{{ dataset.source }}</a></td>
+              <td>{{ dataset.row_count }}</td>
+              <td>{{ dataset.retrieved_at }}</td>
+              <td><span class="status-pill">{{ dataset.quality_status }}</span></td>
+              <td>{{ dataset.retrieval_mode or 'official adapter' }}{% if dataset.point_in_time_vintage is sameas false %}<small class="cell-warning">取得時点スナップショット</small>{% endif %}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <div class="empty-state"><h3>公開用スナップショット未生成</h3><p>GitHub Actionsの一次データ取得後に、件数・取得日時・品質状態を表示します。</p></div>
+      {% endif %}
+    </section>
+
+    <section class="section" id="use-case-status" aria-labelledby="use-case-title">
+      <div class="section-heading"><div><p class="eyebrow">Use-case migration</p><h2 id="use-case-title">分析別の接続状態</h2><p>停止中も異常ではありません。利用権、秘密性、比較可能性を満たさない分析は、数値を生成しないことを正常動作とします。</p></div></div>
+      <div class="case-table-shell" tabindex="0" aria-label="分析別データ状態。横方向にスクロールできます。">
+        <table class="case-table data-use-case-table">
+          <caption>各分析の正準移行、一次ソース、必要データ、停止理由</caption>
+          <thead><tr><th scope="col">分析</th><th scope="col">実行状態</th><th scope="col">一次ソース</th><th scope="col">必要データ・契約</th><th scope="col">判断</th></tr></thead>
+          <tbody>
+          {% for use_case in status.use_cases %}
+            <tr data-use-case-state="{{ use_case.runtime_state }}">
+              <td><a class="table-title" href="../{{ use_case.slug }}/index.html"><span><strong>{{ use_case.title }}</strong><small>{{ use_case.slug }}</small></span></a></td>
+              <td><span class="status-pill">{{ state_labels.get(use_case.runtime_state, use_case.runtime_state) }}</span></td>
+              <td>{{ use_case.owner_source }}</td>
+              <td>
+                {% if use_case.required_datasets %}<strong>{{ use_case.required_datasets|join(', ') }}</strong>{% endif %}
+                {% if use_case.missing_datasets %}<small class="cell-warning">未取得: {{ use_case.missing_datasets|join(', ') }}</small>{% endif %}
+                {% for contract in use_case.required_contracts %}<small class="cell-secondary">{{ contract.name }} · {{ contract.automation_status }}</small>{% endfor %}
+              </td>
+              <td>{{ use_case.note }}{% for contract in use_case.required_contracts if contract.block_reason %}<small class="cell-warning">{{ contract.block_reason }}</small>{% endfor %}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="contract-title">
+      <div class="section-heading"><div><p class="eyebrow">Operational contract</p><h2 id="contract-title">OKの定義</h2></div></div>
+      <div class="process-grid">
+        <div class="process-step"><span>01</span><h3>一次情報</h3><p>公式APIまたは統制された非公開入力だけを受け付けます。</p></div>
+        <div class="process-step"><span>02</span><h3>来歴と品質</h3><p>raw SHA-256、取得時刻、主キー、NULL、重複、非有限値を検査します。</p></div>
+        <div class="process-step"><span>03</span><h3>停止も正常</h3><p>利用権や入力が不足する場合は、推測せず理由付きで停止します。</p></div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer shell"><div class="footer-inner"><span>CrewTrade</span><span>Evidence before output.</span></div></footer>
+</body>
+</html>


### PR DESCRIPTION
## 変更

- クレジット分析をETF価格比からFRED ICE BofA OASへ完全移行
- 金利分析を公式Treasury/FRED系列へ移行し、信用OAS・固定資産配分・Kronos予測を分離
- OracleをSEC提出履歴・XBRL Company Factsへ移行し、静的FY2026 Q2入力を廃止
- 著名投資家を固定ティッカー配列からSEC 13F information tableへ移行
- SEC 13F XMLの取得、raw保存、CUSIP・株数・報告価額・四半期差分を追加
- FRED APIキーがない場合も公式公開CSVで取得時点スナップショットを作成
- 10テーマの正準稼働・契約停止・非公開入力状態を機械可読レジストリ化
- `data-status/index.html` をPagesへ追加し、データセット件数・取得時刻・品質・停止理由を公開
- main push・毎日05:17 JSTに一次データ、4分析レポート、公開状態を自動更新
- テーマごとの更新日を認める動的Pages監査へ変更
- パーサー、gold view、分析切替、公開状態のオフライン試験を追加

## OKの定義

- 正準接続済み4分析の必要データセットが揃う
- 残る6分析は推測せず、契約待ち・一部利用可能・非公開入力待ちとして明示される
- raw SHA-256、Parquet、DuckDB、品質結果、Pages状態が一致する
- 静的サイト・データ状態の両監査が成功する

## PR検証

- `Build and audit research catalogue`: success
  - Python/JavaScript構文: success
  - 静的カタログ生成: success
  - テーマ別動的更新日監査: success
  - データ状態ページ生成・監査: success
  - ホーム導線・秘密情報非公開監査: success
- `Validate canonical data platform`: success
  - 正準取得・分析コード構文: success
  - データソース設定: success
  - オフライン契約試験: success
  - raw→Parquet→DuckDB実書込み: success
- `Deploy to GitHub Pages`: success

マージ後のlive-snapshotで公式FRED、Treasury、SEC、13F明細を実取得し、4分析の最新レポートとPages状態を`OK`へ昇格させます。