### PR TITLE
Make canonical Pages publishing race-safe

### DIFF
--- a/.github/workflows/data-platform.yml
+++ b/.github/workflows/data-platform.yml
@@ -151,5 +151,6 @@ jobs:
             echo "Published reports and status are current."
           else
             git commit -m "Refresh canonical data reports and status"
-            git push
+            git pull --rebase origin main
+            git push origin HEAD:main
           fi

--- a/.github/workflows/uiux-static-site.yml
+++ b/.github/workflows/uiux-static-site.yml
@@ -70,5 +70,6 @@ jobs:
             echo "Generated docs are current."
           else
             git commit -m "Rebuild published research catalogue [skip ci]"
-            git push
+            git pull --rebase origin main
+            git push origin HEAD:main
           fi

--- a/crew/legendary_investors/reporting.py
+++ b/crew/legendary_investors/reporting.py
@@ -75,7 +75,7 @@ class LegendaryInvestorsReporter:
             ascending=[True, False],
         ).iterrows():
             lines.append(
-                f"| {row['manager_display_name']} | {row['issuer']} | {row['title_of_class']} | `{row['cusip']}` | {row['put_call'] or '—'} | {_format_number(row['reported_value'])} | {_format_percent(row['portfolio_weight'])} | {_format_number(row['shares_or_principal'])} {row['shares_or_principal_type'] or ''} |"
+                f"| {_format_text(row['manager_display_name'])} | {_format_text(row['issuer'])} | {_format_text(row['title_of_class'])} | `{_format_text(row['cusip'])}` | {_format_text(row['put_call'])} | {_format_number(row['reported_value'])} | {_format_percent(row['portfolio_weight'])} | {_format_number(row['shares_or_principal'])} {_format_text(row['shares_or_principal_type'], fallback='')} |"
             )
 
         lines.extend(
@@ -116,7 +116,7 @@ class LegendaryInvestorsReporter:
             )
             for _, row in changes.head(20).iterrows():
                 lines.append(
-                    f"| {row['manager_display_name']} | {row['issuer']} | `{row['cusip']}` | {row['change_type']} | {_format_signed(row['share_change'])} | {_format_signed(row['value_change'])} |"
+                    f"| {_format_text(row['manager_display_name'])} | {_format_text(row['issuer'])} | `{_format_text(row['cusip'])}` | {_format_text(row['change_type'])} | {_format_signed(row['share_change'])} | {_format_signed(row['value_change'])} |"
                 )
 
         lines.extend(
@@ -168,6 +168,13 @@ def _frame(payload: Dict[str, Any], key: str, *, required: bool = True) -> pd.Da
     if required:
         raise TypeError(f"Expected DataFrame payload: {key}")
     return pd.DataFrame()
+
+
+def _format_text(value: object, *, fallback: str = "—") -> str:
+    if value is None or pd.isna(value):
+        return fallback
+    text = str(value).strip()
+    return text or fallback
 
 
 def _format_number(value: object) -> str:


### PR DESCRIPTION
## 変更

- データ取得workflowと静的Pages workflowが同時にmainへpushしても、commit後に`git pull --rebase origin main`を行ってからpushするよう修正
- SEC 13Fの任意項目が欠損・`pd.NA`でもレポート生成を停止しない表示整形を追加

## 根因

PR #20のマージ後、静的docs生成と正準データ取得が並行実行されます。静的workflowが先にmainを進めると、データworkflowの成果が非fast-forwardでpushできない競合が発生し得ます。これにより一次データ取得が成功してもPages状態が`degraded`のまま残ります。

## 検証

PR CIで正準データ契約、静的カタログ、データ状態ページを再検証します。マージ後にlive-snapshotを再実行し、公開状態`OK`まで確認します。