### PR TITLE
Blocked: SEC rejects GitHub-hosted runners

### DIFF
--- a/.github/workflows/sec-network-smoke.yml
+++ b/.github/workflows/sec-network-smoke.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   probe:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Probe official SEC endpoints
         env:

--- a/.github/workflows/sec-network-smoke.yml
+++ b/.github/workflows/sec-network-smoke.yml
@@ -1,0 +1,44 @@
+name: Diagnose SEC network paths
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/sec-network-smoke.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe official SEC endpoints
+        env:
+          SEC_USER_AGENT: CrewTrade 137051370+KAFKA2306@users.noreply.github.com
+        run: |
+          set +e
+          urls=(
+            "https://data.sec.gov/submissions/CIK0001341439.json"
+            "https://www.sec.gov/Archives/edgar/full-index/2026/QTR2/master.idx"
+            "https://www.sec.gov/Archives/edgar/data/1029160/000090266426002529/0000902664-26-002529-index.htm"
+            "https://www.sec.gov/Archives/edgar/data/1029160/000090266426002529/xslForm13F_X02/infotable.xml"
+            "https://www.sec.gov/Archives/edgar/data/1341439/000119312526101045/orcl-20260228.htm"
+            "https://www.sec.gov/Archives/edgar/data/1341439/000119312526101045/orcl-20260228_htm.xml"
+            "https://www.sec.gov/data-research/sec-markets-data/form-13f-data-sets"
+            "https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK=1341439&type=10-Q&output=atom"
+            "https://efts.sec.gov/LATEST/search-index?q=oracle&forms=10-Q&ciks=1341439&from=0&size=1"
+          )
+          for url in "${urls[@]}"; do
+            status=$(curl --http1.1 --compressed --silent --show-error \
+              --location \
+              --output /tmp/sec-probe-body \
+              --write-out "%{http_code}" \
+              --header "User-Agent: ${SEC_USER_AGENT}" \
+              --header "From: 137051370+KAFKA2306@users.noreply.github.com" \
+              --header "Accept: */*" \
+              "$url")
+            bytes=$(wc -c < /tmp/sec-probe-body | tr -d ' ')
+            content=$(file --brief --mime-type /tmp/sec-probe-body)
+            echo "${status} ${bytes} ${content} ${url}"
+          done


### PR DESCRIPTION
## 結論

Treasuryの実装障害は解消しましたが、SECの全公式経路がGitHub-hosted runnerをHTTP 403で拒否しました。第三者プロキシや未検証キャッシュで`canonical_active`を偽装しないため、本PRはマージしません。

## 検証済み

- Treasury名目・実質年次XML: 成功
- `DatetimeIndex`正規化: 成功
- 実質`TC_*`フィールド: 成功
- SEC User-Agent / From宣言: 実施
- Ubuntu x64 / macOS / Ubuntu Arm64: SEC公式経路すべて403

診断証跡はPRコメントに記録済みです。

## 現在の正確なPages契約

```text
正準稼働       1
統制状態       9
取得待ち       0
overall_status OK
Pages監査      PASS
```

Oracle・著名投資家を正準稼働へ戻すには、SECへ到達可能な永続またはself-hosted runnerの実測検証が必要です。