### PR TITLE
Publish canonical status and Pages atomically

### DIFF
--- a/.github/workflows/data-platform.yml
+++ b/.github/workflows/data-platform.yml
@@ -136,6 +136,13 @@ jobs:
           print("Canonical Pages status is OK")
           PY
 
+      - name: Build and audit published Pages
+        run: |
+          uv run python web/build_static.py
+          uv run python web/audit_static.py
+          uv run python web/build_data_status.py
+          uv run python web/audit_data_status.py
+
       - name: Show ingestion state
         run: uv run crew-data status
 
@@ -147,19 +154,20 @@ jobs:
             data/platform
             web/generated/data-platform-status.json
             output/use_cases/yield_spread
+            docs
           retention-days: 30
           if-no-files-found: error
 
-      - name: Publish report and status on main
+      - name: Publish report, status, and Pages on main
         if: github.ref == 'refs/heads/main'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add web/generated/data-platform-status.json output/use_cases/yield_spread
+          git add web/generated/data-platform-status.json output/use_cases/yield_spread docs
           if git diff --cached --quiet; then
-            echo "Published report and status are current."
+            echo "Published report, status, and Pages are current."
           else
-            git commit -m "Refresh canonical data report and status"
+            git commit -m "Refresh canonical data report, status, and Pages"
             git pull --rebase origin main
             git push origin HEAD:main
           fi


### PR DESCRIPTION
## 変更

- 財務省ライブ取得後に、正準状態JSON・金利レポート・静的Pagesを同じjob内で生成
- `web/build_static.py`、静的監査、データ状態ページ生成・監査をライブjobへ追加
- `web/generated/data-platform-status.json`、`output/use_cases/yield_spread`、`docs`を同一コミットでmainへ公開
- GitHub Actionsの`GITHUB_TOKEN`によるコミットが後続workflowを起動しない制約に依存しない構造へ変更

## 完了条件

- 正準状態が`OK`（正準1、統制9、取得待ち0）
- `docs/site-manifest.json`も同じ`OK`状態を保持
- 調査カタログ・状態ページの静的監査が成功
- Pages配信が成功